### PR TITLE
Add varied idle locations and bathroom breaks with thought bubbles

### DIFF
--- a/src/game/character/animations.ts
+++ b/src/game/character/animations.ts
@@ -537,6 +537,7 @@ export function activityToAnimation(
     play_instrument: 'play_instrument',
     tinker: 'tinker',
     rummage: 'rummage',
+    use_bathroom: 'sit',
     idle: 'idle',
   }
   return map[activity] ?? 'idle'

--- a/src/game/character/phrases.ts
+++ b/src/game/character/phrases.ts
@@ -23,6 +23,7 @@ export type PhraseCategory =
   | 'bathing'
   | 'sleeping'
   | 'hobby'
+  | 'bathroom_break'
 
 // ---------------------------------------------------------------------------
 // Phrase lists
@@ -117,6 +118,18 @@ export const PHRASES: Readonly<Record<PhraseCategory, readonly string[]>> = {
     "In the zone.",
     "This is my happy place.",
   ],
+  bathroom_break: [
+    "💩",
+    "🚽 Occupied!",
+    "Do NOT come in.",
+    "...nature calls.",
+    "💩💩💩",
+    "Ahh, much better.",
+    "🧻",
+    "This might take a while...",
+    "La la la... 🎵",
+    "Nobody look.",
+  ],
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +171,7 @@ export function selectPhraseCategory(
   if (activity === 'cook') return 'cooking'
   if (activity === 'eat') return 'eating'
   if (activity === 'bathe' || activity === 'groom') return 'bathing'
+  if (activity === 'use_bathroom') return 'bathroom_break'
   if (activity === 'sleep') return 'sleeping'
   if (activity === 'work' || activity === 'type') return 'working'
   if (

--- a/src/game/character/schedule.ts
+++ b/src/game/character/schedule.ts
@@ -85,6 +85,7 @@ const BASE_SCHEDULE: readonly ScheduleSlot[] = [
       { room: 'hobby_room', activity: 'paint', durationHours: 1, weight: 4 },
       { room: 'hobby_room', activity: 'tinker', durationHours: 1, weight: 3 },
       { room: 'hobby_room', activity: 'play_instrument', durationHours: 1, weight: 3 },
+      { room: 'bathroom', activity: 'use_bathroom', durationHours: 0.25, weight: 1 },
     ],
   },
   // 12pm – 1pm: lunch
@@ -108,6 +109,7 @@ const BASE_SCHEDULE: readonly ScheduleSlot[] = [
       { room: 'hobby_room', activity: 'tinker', durationHours: 1, weight: 3 },
       { room: 'hobby_room', activity: 'play_instrument', durationHours: 1, weight: 3 },
       { room: 'study', activity: 'read', durationHours: 0.75, weight: 2 },
+      { room: 'bathroom', activity: 'use_bathroom', durationHours: 0.25, weight: 1 },
     ],
   },
   // 5pm – 7pm: dinner prep / eating
@@ -130,6 +132,7 @@ const BASE_SCHEDULE: readonly ScheduleSlot[] = [
       { room: 'hobby_room', activity: 'play_instrument', durationHours: 1, weight: 3 },
       { room: 'hobby_room', activity: 'tinker', durationHours: 1, weight: 2 },
       { room: 'study', activity: 'read', durationHours: 0.75, weight: 3 },
+      { room: 'bathroom', activity: 'use_bathroom', durationHours: 0.25, weight: 1 },
     ],
   },
   // 11pm – midnight: bed
@@ -214,6 +217,23 @@ const CRITICAL_NEED_RESOLUTION: Readonly<
 }
 
 // ---------------------------------------------------------------------------
+// Idle location variety
+// ---------------------------------------------------------------------------
+
+/**
+ * Comfortable rooms the character may wander to when idling.
+ * Excludes staircase (transit hub), entrance (too small), and storage (not cozy).
+ */
+const COZY_IDLE_ROOMS: readonly RoomId[] = [
+  'living_room',
+  'kitchen',
+  'bedroom',
+  'study',
+  'hobby_room',
+  'bathroom',
+]
+
+// ---------------------------------------------------------------------------
 // Main selection function
 // ---------------------------------------------------------------------------
 
@@ -271,7 +291,9 @@ export function selectNextActivity(
   })
 
   if (viableCandidates.length === 0) {
-    return { room: 'bedroom', activity: 'idle', durationHours: 0.25 }
+    const idleRoom = rng.pick(COZY_IDLE_ROOMS)
+    const idleActivity = idleRoom === 'bathroom' ? 'use_bathroom' as ActivityType : 'idle' as ActivityType
+    return { room: idleRoom, activity: idleActivity, durationHours: 0.25 }
   }
 
   const weights = viableCandidates.map((c) => {
@@ -358,6 +380,7 @@ export function describeActivity(activity: ActivityType): string {
     play_instrument: 'playing music',
     tinker: 'tinkering',
     rummage: 'rummaging around',
+    use_bathroom: 'using the bathroom',
     idle: 'standing around',
   }
   return descriptions[activity] ?? activity

--- a/src/game/rooms.ts
+++ b/src/game/rooms.ts
@@ -38,6 +38,7 @@ export type ActivityType =
   | 'play_instrument'
   | 'tinker'
   | 'rummage'
+  | 'use_bathroom'
   | 'idle'
 
 // ---------------------------------------------------------------------------
@@ -123,7 +124,7 @@ export const ROOMS: readonly Room[] = [
     id: 'bathroom',
     floor: 2,
     center: new THREE.Vector3(17, floorCenterY(2), 4),
-    activities: ['bathe', 'groom', 'idle'],
+    activities: ['bathe', 'groom', 'use_bathroom', 'idle'],
     adjacentRooms: ['bedroom', 'study', 'staircase'],
   },
   {


### PR DESCRIPTION
Instead of always defaulting to the bedroom when idling, the character
now picks from several cozy rooms (living room, kitchen, study, hobby
room, bedroom, bathroom) using the seeded RNG for deterministic variety.

Adds a new 'use_bathroom' activity so the character occasionally
disappears into the bathroom with fun emoji thought bubbles.

https://claude.ai/code/session_01LX6P7QH4NzgFwdiLPRL6CM