### PR TITLE
Fix send button overlapping with feedback FAB

### DIFF
--- a/src/components/VisitorPanel.tsx
+++ b/src/components/VisitorPanel.tsx
@@ -269,6 +269,7 @@ const styles: Record<string, React.CSSProperties> = {
     alignItems: 'center',
     gap: '8px',
     marginBottom: '4px',
+    paddingRight: '56px', // clear the fixed-position feedback FAB
   },
   prompt: {
     color: CRT_DIM,
@@ -309,5 +310,6 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '11px',
     textAlign: 'right' as const,
     textShadow: 'none',
+    paddingRight: '56px', // match inputRow offset for feedback FAB
   },
 }


### PR DESCRIPTION
Add right padding to the visitor panel input row and character count
so the SEND button no longer sits behind the fixed-position feedback
button when the panel is expanded with messages.

https://claude.ai/code/session_015LdppZn7UJoBwFEB1AgNTo