### PR TITLE
Slow down floor movement speed from 0.4 to 0.2

### DIFF
--- a/src/game/character/character.ts
+++ b/src/game/character/character.ts
@@ -60,7 +60,7 @@ import { pickPhrase, selectPhraseCategory } from './phrases'
 export const REAL_SECONDS_PER_GAME_MINUTE = 1 / 10
 
 /** Movement speed: how many path-leg progress units per real second */
-const MOVEMENT_SPEED = 0.4
+const MOVEMENT_SPEED = 0.2
 
 /** Staircase traversal speed: progress units per real second */
 const STAIRCASE_SPEED = 0.3


### PR DESCRIPTION
Halves the MOVEMENT_SPEED constant so characters walk at a more
natural pace on floors. Stair climbing speed (STAIRCASE_SPEED = 0.3)
is left unchanged.

https://claude.ai/code/session_01DsF8UKzHkq4TLaCiycyKX4