### PR TITLE
Fix character clipping behind first stair step on every floor

### DIFF
--- a/src/game/character/pathfinder.ts
+++ b/src/game/character/pathfinder.ts
@@ -153,10 +153,11 @@ export function getPositionAlongLeg(
 export const STAIR_X = ROOM_MAP['staircase'].center.x  // 29.5
 
 /**
- * Z coordinate of the bottom step (front of house, closest to camera).
- * The camera looks in the +Z direction so low-Z = close to viewer.
+ * Z coordinate where the character enters/exits the staircase at the bottom.
+ * Positioned in front of the first step (step 0 front face is at Z = 0.5)
+ * so the character never clips inside step geometry.
  */
-export const STAIR_Z_BOTTOM = 1
+export const STAIR_Z_BOTTOM = 0
 
 /**
  * Z coordinate near the top step (toward back wall).


### PR DESCRIPTION
STAIR_Z_BOTTOM was set to 1 (center of step 0), placing the character
inside the first step's geometry at the start of each climb. Step 0
occupies Z=[0.5,1.5] and Y=[baseY+1,baseY+2], so a character at
Z=1/Y=baseY+1 renders behind the step.

Changed STAIR_Z_BOTTOM from 1 to 0, positioning the character in front
of the first step before climbing begins. The linear Y interpolation
over the wider Z range keeps the character above every step surface
throughout the climb, preserving smooth transitions.

https://claude.ai/code/session_0189o2xH4sAaeKjQg35bDBq8