### PR TITLE
Add procedural footstep SFX synthesis system

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -86,6 +86,7 @@ export function GameCanvas({ characterName = 'resident', initialState, onGameRea
 
     function onTouchStart(e: TouchEvent): void {
       e.preventDefault()
+      gameRef.current?.unlockAudio()
       if (e.touches.length === 1) {
         touchStateRef.current = {
           type: 'pan',
@@ -168,6 +169,7 @@ export function GameCanvas({ characterName = 'resident', initialState, onGameRea
     if (!container) return
 
     function onMouseDown(e: MouseEvent): void {
+      gameRef.current?.unlockAudio()
       mouseStateRef.current = { isDown: true, lastX: e.clientX, lastY: e.clientY }
       container!.style.cursor = 'grabbing'
     }

--- a/src/game/character/character.ts
+++ b/src/game/character/character.ts
@@ -45,6 +45,12 @@ import type { AnimationState } from './animations'
 import type { RoomId, ActivityType } from '../rooms'
 import { getRoom } from '../rooms'
 import { pickPhrase, selectPhraseCategory } from './phrases'
+import type { SfxEngine } from '../sfx/engine'
+import {
+  createFootstepDetectorState,
+  detectFootsteps,
+} from '../sfx/footstepDetector'
+import type { FootstepDetectorState } from '../sfx/footstepDetector'
 
 // ---------------------------------------------------------------------------
 // Configurable constants
@@ -121,8 +127,12 @@ export class Character {
   private _accessories: ClothingItem[] = []
   /** Clothing item queued to be applied after the next 'dress' activity completes */
   private _clothingQueue: ClothingItem | null = null
+  /** SFX engine for procedural sound synthesis (null if audio unavailable) */
+  private sfx: SfxEngine | null = null
+  /** Tracks animation progress to detect foot-down moments */
+  private footstepDetector: FootstepDetectorState = createFootstepDetectorState()
 
-  constructor(name: string, scene: THREE.Scene, initialState?: CharacterState) {
+  constructor(name: string, scene: THREE.Scene, initialState?: CharacterState, sfx?: SfxEngine) {
     this.name = name
     this.scene = scene
 
@@ -177,6 +187,8 @@ export class Character {
     if (this.currentActivity === 'sleep') {
       this.fsm.transitionToSleeping()
     }
+
+    this.sfx = sfx ?? null
   }
 
   // -------------------------------------------------------------------------
@@ -231,6 +243,17 @@ export class Character {
     // --- 4. Apply animation ---
     this.animationState = advanceAnimation(this.animationState, deltaTime)
     applyAnimation(this.mesh.parts, this.animationState)
+
+    // --- 4b. Detect and play footstep sounds ---
+    if (this.sfx) {
+      const footstepEvents = detectFootsteps(
+        this.footstepDetector,
+        this.animationState,
+      )
+      for (const event of footstepEvents) {
+        this.sfx.playFootstep(event.surface)
+      }
+    }
 
     // Rotate character to face movement direction if moving
     if (state.kind === 'active/moving' || state.kind === 'transitioning') {

--- a/src/game/renderer.ts
+++ b/src/game/renderer.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three'
 import { buildHouse, HOUSE_WIDTH, FLOOR_HEIGHT, FLOOR_COUNT, HOUSE_DEPTH } from './house'
 import type { GameInstance } from './types'
 import { Character } from './character'
+import { SfxEngine } from './sfx/engine'
 import type { CharacterState as SchemaCharacterState } from '@/lib/characterSchema'
 import type { ClothingItem } from '@/lib/characterSchema'
 import type { RoomId, ActivityType } from './rooms'
@@ -73,6 +74,7 @@ export function initGame(
       putOnClothes() {},
       goToRoom() {},
       getCharacterState() { return null },
+      unlockAudio() {},
     }
   }
   renderer.setPixelRatio(window.devicePixelRatio)
@@ -205,7 +207,12 @@ export function initGame(
       }
     : undefined
 
-  const character = new Character(characterName, scene, gameCharacterState)
+  // ------------------------------------------------------------------
+  // SFX
+  // ------------------------------------------------------------------
+  const sfxEngine = new SfxEngine()
+
+  const character = new Character(characterName, scene, gameCharacterState, sfxEngine)
 
   // ------------------------------------------------------------------
   // Animation loop
@@ -264,6 +271,7 @@ export function initGame(
       cancelAnimationFrame(animFrameId)
       resizeObserver.disconnect()
       character.dispose()
+      sfxEngine.dispose()
       renderer.dispose()
     },
     getCurrentThought() {
@@ -329,6 +337,9 @@ export function initGame(
         position: s.position,
         accessories: s.accessories,
       }
+    },
+    unlockAudio() {
+      sfxEngine.unlock()
     },
   }
 }

--- a/src/game/sfx/engine.ts
+++ b/src/game/sfx/engine.ts
@@ -1,0 +1,192 @@
+// ---------------------------------------------------------------------------
+// SFX Engine — procedural sound synthesis via Web Audio API
+// ---------------------------------------------------------------------------
+//
+// Manages the AudioContext lifecycle and synthesizes footstep sounds.
+// AudioContext is created lazily on user gesture (browser policy requires this).
+// All methods silently no-op when audio is unavailable (headless, SSR, etc.).
+
+import type { SurfaceType } from './footstepDetector'
+
+// ---------------------------------------------------------------------------
+// SFX Engine
+// ---------------------------------------------------------------------------
+
+export class SfxEngine {
+  private ctx: AudioContext | null = null
+  private masterGain: GainNode | null = null
+  private _unlocked = false
+
+  /** Pre-allocated noise buffers, created once in unlock() and reused */
+  private woodNoiseBuf: AudioBuffer | null = null
+  private stairsNoiseBuf: AudioBuffer | null = null
+
+  /**
+   * Creates and resumes the AudioContext. Must be called from a user gesture
+   * handler (touchstart, mousedown, click). Idempotent — safe to call repeatedly.
+   */
+  unlock(): void {
+    if (this._unlocked) return
+    try {
+      this.ctx = new AudioContext()
+      this.masterGain = this.ctx.createGain()
+      this.masterGain.gain.value = 0.15
+      this.masterGain.connect(this.ctx.destination)
+      if (this.ctx.state === 'suspended') {
+        void this.ctx.resume()
+      }
+      this._prepareNoiseBuffers()
+      this._unlocked = true
+    } catch {
+      // Web Audio unavailable — silently degrade
+      this.ctx = null
+      this.masterGain = null
+    }
+  }
+
+  get isUnlocked(): boolean {
+    return this._unlocked
+  }
+
+  playFootstep(surface: SurfaceType): void {
+    if (!this.ctx || !this.masterGain) return
+    if (surface === 'stairs') {
+      this._playStairsFootstep()
+    } else {
+      this._playWoodFootstep()
+    }
+  }
+
+  dispose(): void {
+    if (this.ctx) {
+      void this.ctx.close()
+      this.ctx = null
+      this.masterGain = null
+      this.woodNoiseBuf = null
+      this.stairsNoiseBuf = null
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Noise buffer preparation
+  // -------------------------------------------------------------------------
+
+  private _prepareNoiseBuffers(): void {
+    if (!this.ctx) return
+
+    // Wood: 40ms noise burst
+    const woodLen = Math.floor(this.ctx.sampleRate * 0.04)
+    this.woodNoiseBuf = this.ctx.createBuffer(1, woodLen, this.ctx.sampleRate)
+    const woodData = this.woodNoiseBuf.getChannelData(0)
+    for (let i = 0; i < woodLen; i++) {
+      woodData[i] = (Math.random() * 2 - 1) * 0.5
+    }
+
+    // Stairs: 60ms noise burst
+    const stairsLen = Math.floor(this.ctx.sampleRate * 0.06)
+    this.stairsNoiseBuf = this.ctx.createBuffer(1, stairsLen, this.ctx.sampleRate)
+    const stairsData = this.stairsNoiseBuf.getChannelData(0)
+    for (let i = 0; i < stairsLen; i++) {
+      stairsData[i] = (Math.random() * 2 - 1) * 0.4
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Randomization helper
+  // -------------------------------------------------------------------------
+
+  /** Returns base * (1 + random offset in [-spread, +spread]) */
+  private _jitter(base: number, spread: number): number {
+    return base * (1 + (Math.random() * 2 - 1) * spread)
+  }
+
+  // -------------------------------------------------------------------------
+  // Wood floor footstep — short, dry tap
+  // -------------------------------------------------------------------------
+
+  private _playWoodFootstep(): void {
+    const ctx = this.ctx!
+    const now = ctx.currentTime
+
+    // --- Tone: short pitched click (square wave, retro character) ---
+    const osc = ctx.createOscillator()
+    osc.type = 'square'
+    const startFreq = this._jitter(180, 0.08)
+    osc.frequency.setValueAtTime(startFreq, now)
+    osc.frequency.exponentialRampToValueAtTime(80, now + 0.06)
+
+    const oscGain = ctx.createGain()
+    oscGain.gain.setValueAtTime(this._jitter(0.3, 0.1), now)
+    oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.08)
+
+    // --- Noise: high-end transient texture ---
+    const noise = ctx.createBufferSource()
+    noise.buffer = this.woodNoiseBuf
+
+    const noiseFilter = ctx.createBiquadFilter()
+    noiseFilter.type = 'highpass'
+    noiseFilter.frequency.value = 2000
+
+    const noiseGain = ctx.createGain()
+    noiseGain.gain.setValueAtTime(0.15, now)
+    noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.04)
+
+    // --- Connect ---
+    osc.connect(oscGain).connect(this.masterGain!)
+    noise.connect(noiseFilter).connect(noiseGain).connect(this.masterGain!)
+
+    // --- Schedule ---
+    osc.start(now)
+    osc.stop(now + 0.08)
+    noise.start(now)
+    noise.stop(now + 0.04)
+  }
+
+  // -------------------------------------------------------------------------
+  // Stairs footstep — deeper, hollow, resonant
+  // -------------------------------------------------------------------------
+
+  private _playStairsFootstep(): void {
+    const ctx = this.ctx!
+    const now = ctx.currentTime
+
+    // --- Tone: deeper triangle wave with resonance ---
+    const osc = ctx.createOscillator()
+    osc.type = 'triangle'
+    const startFreq = this._jitter(120, 0.08)
+    osc.frequency.setValueAtTime(startFreq, now)
+    osc.frequency.exponentialRampToValueAtTime(55, now + 0.12)
+
+    const resonance = ctx.createBiquadFilter()
+    resonance.type = 'bandpass'
+    resonance.frequency.value = 200
+    resonance.Q.value = 5
+
+    const oscGain = ctx.createGain()
+    oscGain.gain.setValueAtTime(this._jitter(0.35, 0.1), now)
+    oscGain.gain.exponentialRampToValueAtTime(0.001, now + 0.15)
+
+    // --- Noise: mid-range wooden creak ---
+    const noise = ctx.createBufferSource()
+    noise.buffer = this.stairsNoiseBuf
+
+    const noiseFilter = ctx.createBiquadFilter()
+    noiseFilter.type = 'bandpass'
+    noiseFilter.frequency.value = 800
+    noiseFilter.Q.value = 3
+
+    const noiseGain = ctx.createGain()
+    noiseGain.gain.setValueAtTime(0.12, now)
+    noiseGain.gain.exponentialRampToValueAtTime(0.001, now + 0.06)
+
+    // --- Connect ---
+    osc.connect(resonance).connect(oscGain).connect(this.masterGain!)
+    noise.connect(noiseFilter).connect(noiseGain).connect(this.masterGain!)
+
+    // --- Schedule ---
+    osc.start(now)
+    osc.stop(now + 0.15)
+    noise.start(now)
+    noise.stop(now + 0.06)
+  }
+}

--- a/src/game/sfx/footstepDetector.ts
+++ b/src/game/sfx/footstepDetector.ts
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// Footstep detector — detects "foot down" events from animation progress
+// ---------------------------------------------------------------------------
+//
+// Pure logic module with no Web Audio dependency. Compares previous vs current
+// animation progress and emits footstep events when foot-down thresholds are
+// crossed during walk or climb_stairs animations.
+
+import type { AnimationState } from '../character/animations'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SurfaceType = 'wood' | 'stairs'
+
+export interface FootstepEvent {
+  surface: SurfaceType
+}
+
+export interface FootstepDetectorState {
+  prevProgress: number
+  prevAnimName: string
+  /** Thresholds already fired this half-cycle, prevents double-firing */
+  firedThresholds: Set<number>
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Thresholds where feet touch down in the walk/climb cycle.
+ *
+ * The walk animation uses oscillate(progress, 0, amplitude) which computes
+ * sin(progress * 2pi) * amplitude. Right leg rotation = swing, left = -swing.
+ *
+ * Right foot peaks at progress 0.25 (sin(pi/2) = 1, max forward extension).
+ * Left foot peaks at progress 0.75 (sin(3pi/2) = -1, left leg at max forward).
+ *
+ * Foot-down occurs at these peak-extension points.
+ */
+const FOOT_DOWN_THRESHOLDS = [0.25, 0.75] as const
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function createFootstepDetectorState(): FootstepDetectorState {
+  return {
+    prevProgress: 0,
+    prevAnimName: 'idle',
+    firedThresholds: new Set(),
+  }
+}
+
+/**
+ * Detects footstep events by comparing previous and current animation state.
+ * Returns an array of FootstepEvents (0, 1, or rarely 2 per frame).
+ *
+ * Mutates detectorState in place for efficiency.
+ */
+export function detectFootsteps(
+  state: FootstepDetectorState,
+  current: AnimationState,
+): FootstepEvent[] {
+  const events: FootstepEvent[] = []
+
+  // Only detect during locomotion animations
+  if (current.name !== 'walk' && current.name !== 'climb_stairs') {
+    state.prevProgress = current.progress
+    state.prevAnimName = current.name
+    state.firedThresholds.clear()
+    return events
+  }
+
+  // Reset detector when animation changes
+  if (current.name !== state.prevAnimName) {
+    state.prevProgress = current.progress
+    state.prevAnimName = current.name
+    state.firedThresholds.clear()
+    return events
+  }
+
+  const surface: SurfaceType = current.name === 'climb_stairs' ? 'stairs' : 'wood'
+  const prev = state.prevProgress
+  const curr = current.progress
+
+  for (const threshold of FOOT_DOWN_THRESHOLDS) {
+    if (state.firedThresholds.has(threshold)) {
+      // Already fired — clear once we move far enough past
+      if (Math.abs(curr - threshold) > 0.15) {
+        state.firedThresholds.delete(threshold)
+      }
+      continue
+    }
+
+    // Check if progress crossed the threshold this frame.
+    // Normal case: prev < threshold <= curr
+    // Wrap-around case: progress looped from ~1 back to ~0
+    const crossed =
+      (prev < threshold && curr >= threshold) ||
+      (prev > curr && (threshold <= curr || threshold > prev))
+
+    if (crossed) {
+      events.push({ surface })
+      state.firedThresholds.add(threshold)
+    }
+  }
+
+  state.prevProgress = curr
+  state.prevAnimName = current.name
+  return events
+}

--- a/src/game/sfx/index.ts
+++ b/src/game/sfx/index.ts
@@ -1,0 +1,10 @@
+export { SfxEngine } from './engine'
+export {
+  createFootstepDetectorState,
+  detectFootsteps,
+} from './footstepDetector'
+export type {
+  SurfaceType,
+  FootstepEvent,
+  FootstepDetectorState,
+} from './footstepDetector'

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -72,4 +72,10 @@ export interface GameInstance {
    * Returns the current character state snapshot for persistence.
    */
   getCharacterState(): SchemaCharacterState | null
+  /**
+   * Unlock audio playback. Must be called from a user gesture handler
+   * (touchstart, mousedown, click) to satisfy browser AudioContext policy.
+   * Idempotent — safe to call repeatedly.
+   */
+  unlockAudio(): void
 }

--- a/tests/unit/footstepDetector.test.ts
+++ b/tests/unit/footstepDetector.test.ts
@@ -1,0 +1,117 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createFootstepDetectorState,
+  detectFootsteps,
+} from '../../src/game/sfx/footstepDetector'
+import type { AnimationState } from '../../src/game/character/animations'
+
+describe('footstepDetector', () => {
+  test('no events during idle animation', () => {
+    const state = createFootstepDetectorState()
+    const anim: AnimationState = { name: 'idle', progress: 0.25 }
+    const events = detectFootsteps(state, anim)
+    assert.equal(events.length, 0)
+  })
+
+  test('no events during non-locomotion animations', () => {
+    const state = createFootstepDetectorState()
+    for (const name of ['sit', 'sleep', 'eat', 'type', 'paint'] as const) {
+      const events = detectFootsteps(state, { name, progress: 0.25 })
+      assert.equal(events.length, 0, `should not fire for ${name}`)
+    }
+  })
+
+  test('detects right foot down at progress 0.25 during walk', () => {
+    const state = createFootstepDetectorState()
+    state.prevProgress = 0.2
+    state.prevAnimName = 'walk'
+    const events = detectFootsteps(state, { name: 'walk', progress: 0.26 })
+    assert.equal(events.length, 1)
+    assert.equal(events[0].surface, 'wood')
+  })
+
+  test('detects left foot down at progress 0.75 during walk', () => {
+    const state = createFootstepDetectorState()
+    state.prevProgress = 0.7
+    state.prevAnimName = 'walk'
+    const events = detectFootsteps(state, { name: 'walk', progress: 0.76 })
+    assert.equal(events.length, 1)
+    assert.equal(events[0].surface, 'wood')
+  })
+
+  test('emits stairs surface during climb_stairs', () => {
+    const state = createFootstepDetectorState()
+    state.prevProgress = 0.2
+    state.prevAnimName = 'climb_stairs'
+    const events = detectFootsteps(state, { name: 'climb_stairs', progress: 0.26 })
+    assert.equal(events.length, 1)
+    assert.equal(events[0].surface, 'stairs')
+  })
+
+  test('does not double-fire for same threshold', () => {
+    const state = createFootstepDetectorState()
+    state.prevProgress = 0.24
+    state.prevAnimName = 'walk'
+    // First crossing fires
+    const first = detectFootsteps(state, { name: 'walk', progress: 0.25 })
+    assert.equal(first.length, 1)
+    // Next frame still near 0.25 — should not fire again
+    const second = detectFootsteps(state, { name: 'walk', progress: 0.26 })
+    assert.equal(second.length, 0)
+  })
+
+  test('resets fired thresholds on animation change', () => {
+    const state = createFootstepDetectorState()
+    state.prevProgress = 0.5
+    state.prevAnimName = 'walk'
+    state.firedThresholds.add(0.25)
+    // Switch to idle clears state
+    detectFootsteps(state, { name: 'idle', progress: 0 })
+    assert.equal(state.firedThresholds.size, 0)
+  })
+
+  test('full walk cycle produces exactly 2 footsteps', () => {
+    const state = createFootstepDetectorState()
+    state.prevAnimName = 'walk'
+    state.prevProgress = 0
+    let total = 0
+    // Simulate 60 frames over one full cycle (progress 0 -> 1)
+    for (let i = 1; i <= 60; i++) {
+      const progress = i / 60
+      const events = detectFootsteps(state, { name: 'walk', progress })
+      total += events.length
+    }
+    assert.equal(total, 2, 'Expected exactly 2 footsteps per walk cycle')
+  })
+
+  test('handles progress wrap-around (1.0 -> 0.0)', () => {
+    const state = createFootstepDetectorState()
+    state.prevAnimName = 'walk'
+    // Simulate being just before wrap
+    state.prevProgress = 0.95
+    // Progress wraps around past 0.25
+    const events = detectFootsteps(state, { name: 'walk', progress: 0.05 })
+    // Should not fire 0.75 (already passed) but may fire 0.25 if in range
+    // At 0.05 we haven't reached 0.25 yet, so 0 events expected
+    assert.equal(events.length, 0)
+  })
+
+  test('multiple consecutive cycles produce consistent footsteps', () => {
+    const state = createFootstepDetectorState()
+    state.prevAnimName = 'walk'
+    state.prevProgress = 0
+    let total = 0
+    // 3 full cycles at 60 frames each
+    for (let cycle = 0; cycle < 3; cycle++) {
+      for (let i = 1; i <= 60; i++) {
+        const progress = i / 60
+        const events = detectFootsteps(state, { name: 'walk', progress })
+        total += events.length
+      }
+      // Reset progress for next cycle (simulating the modulo wrap in advanceAnimation)
+      state.prevProgress = 0
+    }
+    assert.equal(total, 6, 'Expected 2 footsteps per cycle * 3 cycles = 6')
+  })
+})


### PR DESCRIPTION
Introduce the game's first audio system using the Web Audio API.
Synthesizes two distinct footstep sounds — a short dry tap for wood
floors (square wave + highpass noise) and a deeper hollow thump for
staircases (triangle wave + bandpass resonance). Footstep events are
detected from animation progress thresholds (0.25 and 0.75 in the
walk/climb cycle). AudioContext is lazily unlocked on user gesture
and silently degrades in headless environments.

https://claude.ai/code/session_01NSt1RJLF3BLpWWksXY5igp