### PR TITLE
Increase chat terminal message limit to 69 with scroll and fall-off highlight

### DIFF
--- a/src/components/VisitorPanel.tsx
+++ b/src/components/VisitorPanel.tsx
@@ -12,6 +12,7 @@ interface VisitorPanelProps {
 const CRT_GREEN = '#33ff33'
 const CRT_DIM = 'rgba(51,255,51,0.55)'
 const FONT = '"Share Tech Mono", "Courier New", Courier, monospace'
+const MESSAGE_LIMIT = 69
 
 function formatAge(iso: string): string {
   const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
@@ -28,6 +29,7 @@ export function VisitorPanel({ characterName, onMessagePosted }: VisitorPanelPro
   const [errorMsg, setErrorMsg] = useState('')
   const [collapsed, setCollapsed] = useState(true)
   const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
 
   const displayName = characterName.replace(/-/g, ' ').toUpperCase()
 
@@ -83,11 +85,12 @@ export function VisitorPanel({ characterName, onMessagePosted }: VisitorPanelPro
     [handleSubmit],
   )
 
-  const recentMessages = log ? [...log.messages].reverse().slice(0, 5) : []
+  const recentMessages = log ? [...log.messages].reverse() : []
+  const atCapacity = recentMessages.length >= MESSAGE_LIMIT
   const count = log?.totalCount ?? 0
 
   return (
-    <div style={{ ...styles.panel, height: collapsed ? '40px' : '260px', transition: 'height 0.2s ease' }}>
+    <div style={{ ...styles.panel, height: collapsed ? '40px' : '420px', transition: 'height 0.2s ease' }}>
       {/* Scanline overlay */}
       <div style={styles.scanlines} aria-hidden="true" />
 
@@ -110,17 +113,29 @@ export function VisitorPanel({ characterName, onMessagePosted }: VisitorPanelPro
         <div style={styles.divider} aria-hidden="true">{'─'.repeat(44)}</div>
 
         {/* Message list */}
-        <div style={styles.messageList}>
+        <div ref={listRef} style={styles.messageList}>
           {recentMessages.length === 0 ? (
             <div style={styles.empty}>NO MESSAGES YET. BE THE FIRST!</div>
           ) : (
-            recentMessages.map((msg, i) => (
-              <div key={i} style={styles.messageRow}>
-                <span style={styles.bullet}>&gt;</span>
-                <span style={styles.msgText}>{msg.text}</span>
-                <span style={styles.timestamp}>{formatAge(msg.postedAt)}</span>
-              </div>
-            ))
+            recentMessages.map((msg, i) => {
+              const isOldest = atCapacity && i === recentMessages.length - 1
+              return (
+                <div
+                  key={i}
+                  style={{
+                    ...styles.messageRow,
+                    ...(isOldest ? styles.fallingOff : undefined),
+                  }}
+                >
+                  <span style={styles.bullet}>&gt;</span>
+                  <span style={styles.msgText}>{msg.text}</span>
+                  <span style={styles.timestamp}>
+                    {isOldest ? 'NEXT \u2192 ' : ''}
+                    {formatAge(msg.postedAt)}
+                  </span>
+                </div>
+              )
+            })
           )}
         </div>
 
@@ -238,7 +253,15 @@ const styles: Record<string, React.CSSProperties> = {
   },
   messageList: {
     minHeight: '72px',
+    maxHeight: '240px',
+    overflowY: 'auto',
     marginBottom: '8px',
+  },
+  fallingOff: {
+    backgroundColor: 'rgba(255, 68, 68, 0.15)',
+    borderLeft: '2px solid rgba(255, 68, 68, 0.6)',
+    paddingLeft: '6px',
+    marginLeft: '-8px',
   },
   empty: {
     opacity: 0.45,

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -48,7 +48,7 @@ export async function appendVisitorMessage(name: string, text: string): Promise<
   }
   const updated: VisitorLog = {
     name: existing.name,
-    messages: [...existing.messages, newMessage].slice(-20),
+    messages: [...existing.messages, newMessage].slice(-69),
     totalCount: existing.totalCount + 1,
   }
   await kv.set(visitorsKey(name), updated)

--- a/src/lib/visitorSchema.ts
+++ b/src/lib/visitorSchema.ts
@@ -7,7 +7,7 @@ export const VisitorMessageSchema = z.object({
 
 export const VisitorLogSchema = z.object({
   name: z.string(),
-  messages: z.array(VisitorMessageSchema).max(20),
+  messages: z.array(VisitorMessageSchema).max(69),
   totalCount: z.number().int().min(0),
 })
 


### PR DESCRIPTION
- Raise visitor message storage and schema cap from 20 to 69
- Show all messages instead of only the 5 most recent
- Make the message list scrollable (maxHeight 240px)
- Highlight the oldest message with a red tint and "NEXT →" label
  when the terminal is at capacity, indicating it will fall off next

https://claude.ai/code/session_012PEwnYFY9qoMyDvAksBrGy