### PR TITLE
Fix route matching to handle query parameters in autosave

### DIFF
--- a/tests/e2e/cowboy-hat.spec.ts
+++ b/tests/e2e/cowboy-hat.spec.ts
@@ -55,9 +55,10 @@ test.describe('Cowboy hat', () => {
     })
 
     // Intercept autosave POSTs and flag when accessories include the hat.
-    // Use $ anchor so this does NOT match the /messages sub-route.
+    // Use (?:\?|$) so we match the path with or without query params (e.g. ?v=1)
+    // but still exclude the /messages sub-route.
     let savedWithHat = false
-    await page.route(/\/api\/character\/playwright$/, async (route) => {
+    await page.route(/\/api\/character\/playwright(?:\?|$)/, async (route) => {
       if (route.request().method() === 'POST') {
         try {
           const body = JSON.parse(route.request().postData() ?? '{}') as {


### PR DESCRIPTION
## Summary

Updates the route matcher in the cowboy hat e2e test to correctly intercept autosave POST requests that include query parameters. The previous regex pattern using `$` anchor would fail to match URLs with query strings like `/api/character/playwright?v=1`.

## Changes

- Updated route pattern from `/\/api\/character\/playwright$/` to `/\/api\/character\/playwright(?:\?|$)/`
- This allows matching both `/api/character/playwright` and `/api/character/playwright?...` while still excluding the `/messages` sub-route
- Updated comment to clarify the intent of the non-capturing group

## Testing

The change is covered by the existing e2e test that verifies autosave functionality with the cowboy hat accessory. The updated regex pattern will now correctly intercept requests regardless of whether query parameters are present.

## Checklist

- [ ] CI checks passing (`ci` workflow: lint + type-check)
- [ ] Smoke tests passing (`smoke` workflow)
- [ ] Code follows project conventions (TypeScript strict, Prettier formatted)
- [ ] No `any` types introduced without an explanatory comment
- [ ] No Tailwind classes added inside `src/game/`
- [ ] Self-reviewed the diff before requesting review

## Notes for reviewer

This is a defensive fix for route matching in the e2e test. While the current test may not be hitting query parameters, this change ensures the test remains robust if query parameters are added to the autosave endpoint in the future.

https://claude.ai/code/session_017G1xUHpkmhQp4TC6WJHM83