### PR TITLE
Add randomized per-character house layouts seeded by name

### DIFF
--- a/src/game/character/character.ts
+++ b/src/game/character/character.ts
@@ -42,8 +42,8 @@ import {
   createAnimationState,
 } from './animations'
 import type { AnimationState } from './animations'
-import type { RoomId, ActivityType } from '../rooms'
-import { getRoom } from '../rooms'
+import type { RoomId, ActivityType, Room } from '../rooms'
+import { ROOM_MAP } from '../rooms'
 import { pickPhrase, selectPhraseCategory } from './phrases'
 import type { SfxEngine } from '../sfx/engine'
 import {
@@ -107,6 +107,7 @@ export class Character {
   private readonly scene: THREE.Scene
   private readonly mesh: CharacterMesh
   private readonly fsm: CharacterStateMachine
+  private readonly roomMap: Readonly<Record<RoomId, Room>>
   private needs: Needs
   private clock: GameClock
   private currentRoom: RoomId
@@ -132,9 +133,16 @@ export class Character {
   /** Tracks animation progress to detect foot-down moments */
   private footstepDetector: FootstepDetectorState = createFootstepDetectorState()
 
-  constructor(name: string, scene: THREE.Scene, initialState?: CharacterState, sfx?: SfxEngine) {
+  constructor(
+    name: string,
+    scene: THREE.Scene,
+    initialState?: CharacterState,
+    sfx?: SfxEngine,
+    roomMap?: Readonly<Record<RoomId, Room>>,
+  ) {
     this.name = name
     this.scene = scene
+    this.roomMap = roomMap ?? ROOM_MAP
 
     // Build appearance from name seed
     const appearance = seedFromName(name)
@@ -162,11 +170,11 @@ export class Character {
     } else {
       this.needs = { ...DEFAULT_NEEDS }
       this.clock = { hour: 8, day: 0 } // Start at 8am on day 0
-      const initial = getInitialActivity(name)
+      const initial = getInitialActivity(name, this.roomMap)
       this.currentRoom = initial.room
       this.currentActivity = initial.activity
       // Place character at room center
-      const room = getRoom(this.currentRoom)
+      const room = this.roomMap[this.currentRoom]
       this.mesh.group.position.copy(room.center)
     }
 
@@ -306,6 +314,7 @@ export class Character {
       movingState.path,
       movingState.pathIndex,
       movingState.legProgress,
+      this.roomMap,
     )
     this.mesh.group.position.copy(pos)
 
@@ -327,7 +336,7 @@ export class Character {
       // Arrived at destination room
       const destRoom = movingState.path[movingState.path.length - 1]
       this.currentRoom = destRoom
-      this.mesh.group.position.copy(getRoom(destRoom).center)
+      this.mesh.group.position.copy(this.roomMap[destRoom].center)
 
       // Start the queued activity
       const { activity, durationHours } = this._getQueuedActivity()
@@ -346,7 +355,7 @@ export class Character {
       const transState = this.fsm.transitioningState
       if (transState) {
         this.currentRoom = transState.destinationRoom
-        this.mesh.group.position.copy(getRoom(this.currentRoom).center)
+        this.mesh.group.position.copy(this.roomMap[this.currentRoom].center)
         const { activity, durationHours } = this._getQueuedActivity()
         this._startPerforming(activity, durationHours)
       }
@@ -377,6 +386,7 @@ export class Character {
       appearance.hobbyType,
       this.currentRoom,
       this.name,
+      this.roomMap,
     )
 
     this.currentActivity = selection.activity
@@ -390,6 +400,7 @@ export class Character {
         this.currentRoom,
         selection.room,
         `${this.name}:path:${this.clock.day}:${Math.floor(this.clock.hour)}`,
+        this.roomMap,
       )
 
       // Queue the activity to start upon arrival
@@ -433,7 +444,7 @@ export class Character {
 
   private _getFacingAngleToRoom(roomId: RoomId): number {
     // Simple: face along X axis based on room position relative to world center
-    const room = getRoom(roomId)
+    const room = this.roomMap[roomId]
     const dx = room.center.x - 8 // 8 is approx house center x
     return dx > 0 ? 0 : Math.PI
   }
@@ -579,6 +590,7 @@ export class Character {
         this.currentRoom,
         room,
         `${this.name}:chat:${this.clock.day}:${Math.floor(this.clock.hour)}`,
+        this.roomMap,
       )
       this._queued = { activity, durationHours }
       this.fsm.transitionToMoving(path)
@@ -602,6 +614,7 @@ export class Character {
         this.currentRoom,
         'bedroom',
         `${this.name}:dress:${this.clock.day}:${Math.floor(this.clock.hour)}`,
+        this.roomMap,
       )
       this._queued = { activity: 'dress', durationHours: 0.15 }
       this.fsm.transitionToMoving(path)

--- a/src/game/character/pathfinder.ts
+++ b/src/game/character/pathfinder.ts
@@ -5,11 +5,11 @@
 // Rooms on the same floor connect directly to each other if they are adjacent.
 // Moving between floors requires passing through the staircase.
 //
-// The adjacency graph is derived from the ROOMS definitions in rooms.ts.
-// We use a simple BFS since the graph is very small (≤ 9 nodes).
+// The adjacency graph is derived from Room definitions (default or layout-
+// specific). We use a simple BFS since the graph is very small (≤ 9 nodes).
 
 import * as THREE from 'three'
-import type { RoomId } from '../rooms'
+import type { RoomId, Room } from '../rooms'
 import { ROOM_MAP, ROOMS, getFloorCenterY } from '../rooms'
 import { seededRngFromKey } from './seeder'
 
@@ -26,41 +26,52 @@ import { seededRngFromKey } from './seeder'
  *     then BFS from there (adds one extra room hop for variety)
  *
  * Without a seed, returns the deterministic shortest path (original BFS).
+ *
+ * An optional `roomMap` can be provided for layout-specific room data.
  */
-export function findPath(from: RoomId, to: RoomId, seed?: string): RoomId[] {
+export function findPath(
+  from: RoomId,
+  to: RoomId,
+  seed?: string,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
+): RoomId[] {
   if (from === to) return [from]
 
   if (!seed) {
-    return _bfsPath(from, to)
+    return _bfsPath(from, to, roomMap)
   }
 
   const rng = seededRngFromKey(seed)
 
   // Scenic detour (30% chance): visit a random neighbor first
-  const fromRoom = ROOM_MAP[from]
+  const fromRoom = roomMap[from]
   const eligibleDetours = fromRoom.adjacentRooms.filter(
     (r) => r !== to && r !== from,
   )
 
   if (rng.next() < 0.3 && eligibleDetours.length > 0) {
     const detourRoom = rng.pick(eligibleDetours)
-    const restPath = _bfsShuffled(detourRoom, to, rng)
+    const restPath = _bfsShuffled(detourRoom, to, rng, roomMap)
     return [from, ...restPath]
   }
 
   // Shuffled BFS (70% chance)
-  return _bfsShuffled(from, to, rng)
+  return _bfsShuffled(from, to, rng, roomMap)
 }
 
 /** Standard deterministic BFS (original implementation). */
-function _bfsPath(from: RoomId, to: RoomId): RoomId[] {
+function _bfsPath(
+  from: RoomId,
+  to: RoomId,
+  roomMap: Readonly<Record<RoomId, Room>>,
+): RoomId[] {
   const queue: RoomId[][] = [[from]]
   const visited = new Set<RoomId>([from])
 
   while (queue.length > 0) {
     const path = queue.shift()!
     const current = path[path.length - 1]
-    const room = ROOM_MAP[current]
+    const room = roomMap[current]
 
     for (const neighbor of room.adjacentRooms) {
       if (visited.has(neighbor)) continue
@@ -79,6 +90,7 @@ function _bfsShuffled(
   from: RoomId,
   to: RoomId,
   rng: { next(): number; pick<T>(arr: readonly T[]): T },
+  roomMap: Readonly<Record<RoomId, Room>>,
 ): RoomId[] {
   if (from === to) return [from]
 
@@ -88,7 +100,7 @@ function _bfsShuffled(
   while (queue.length > 0) {
     const path = queue.shift()!
     const current = path[path.length - 1]
-    const room = ROOM_MAP[current]
+    const room = roomMap[current]
 
     // Shuffle neighbors so BFS explores equally-short paths in random order
     const neighbors = [...room.adjacentRooms]
@@ -113,9 +125,13 @@ function _bfsShuffled(
  * Returns true if the path between two rooms requires traversing the staircase.
  * (i.e., the rooms are on different floors)
  */
-export function requiresStaircase(from: RoomId, to: RoomId): boolean {
+export function requiresStaircase(
+  from: RoomId,
+  to: RoomId,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
+): boolean {
   if (from === to) return false
-  const path = findPath(from, to)
+  const path = findPath(from, to, undefined, roomMap)
   return path.includes('staircase')
 }
 
@@ -138,9 +154,10 @@ export function getPositionAlongLeg(
   fromRoom: RoomId,
   toRoom: RoomId,
   progress: number,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
 ): THREE.Vector3 {
-  const from = ROOM_MAP[fromRoom].center
-  const to = ROOM_MAP[toRoom].center
+  const from = roomMap[fromRoom].center
+  const to = roomMap[toRoom].center
 
   return new THREE.Vector3().lerpVectors(from, to, progress)
 }
@@ -150,7 +167,7 @@ export function getPositionAlongLeg(
 // ---------------------------------------------------------------------------
 
 /** World-space X center of the staircase column */
-export const STAIR_X = ROOM_MAP['staircase'].center.x  // 29.5
+export const STAIR_X = 29.5
 
 /**
  * Z coordinate where the character enters/exits the staircase at the bottom.
@@ -257,6 +274,7 @@ export function getPositionAlongPath(
   path: RoomId[],
   legIndex: number,
   legProgress: number,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
 ): THREE.Vector3 {
   if (path.length === 0) {
     return new THREE.Vector3(0, 0, 0)
@@ -267,7 +285,7 @@ export function getPositionAlongPath(
   const toIdx = Math.max(0, Math.min(legIndex, path.length - 1))
 
   if (fromIdx === toIdx) {
-    return ROOM_MAP[path[fromIdx]].center.clone()
+    return roomMap[path[fromIdx]].center.clone()
   }
 
   const fromRoomId = path[fromIdx]
@@ -276,18 +294,18 @@ export function getPositionAlongPath(
   // ---- Leg toward the staircase ----
   if (toRoomId === 'staircase') {
     const nextRoomId = toIdx < path.length - 1 ? path[toIdx + 1] : null
-    const fromFloor = ROOM_MAP[fromRoomId].floor
-    const nextFloor = nextRoomId ? ROOM_MAP[nextRoomId].floor : fromFloor
+    const fromFloor = roomMap[fromRoomId].floor
+    const nextFloor = nextRoomId ? roomMap[nextRoomId].floor : fromFloor
     const ascending = nextFloor > fromFloor
-    return approachStaircasePosition(ROOM_MAP[fromRoomId].center, ascending, legProgress)
+    return approachStaircasePosition(roomMap[fromRoomId].center, ascending, legProgress)
   }
 
   // ---- Leg away from the staircase ----
   if (fromRoomId === 'staircase') {
     const prevRoomId = fromIdx > 0 ? path[fromIdx - 1] : null
-    const prevFloor = prevRoomId ? ROOM_MAP[prevRoomId].floor : ROOM_MAP[toRoomId].floor
-    const toFloor = ROOM_MAP[toRoomId].floor
-    const destCenter = ROOM_MAP[toRoomId].center
+    const prevFloor = prevRoomId ? roomMap[prevRoomId].floor : roomMap[toRoomId].floor
+    const toFloor = roomMap[toRoomId].floor
+    const destCenter = roomMap[toRoomId].center
 
     // Phase 2 (progress > 0.5): horizontal walk from stair exit to room center
     if (legProgress > 0.5) {
@@ -300,7 +318,7 @@ export function getPositionAlongPath(
   }
 
   // ---- Normal leg between two non-staircase rooms ----
-  return getPositionAlongLeg(fromRoomId, toRoomId, legProgress)
+  return getPositionAlongLeg(fromRoomId, toRoomId, legProgress, roomMap)
 }
 
 /**
@@ -316,9 +334,13 @@ export function getStaircasePosition(floor: 1 | 2 | 3): THREE.Vector3 {
  * Returns the direction the character should face (as a Y-axis rotation angle)
  * when moving from one room to another.
  */
-export function getFacingAngle(fromRoom: RoomId, toRoom: RoomId): number {
-  const from = ROOM_MAP[fromRoom].center
-  const to = ROOM_MAP[toRoom].center
+export function getFacingAngle(
+  fromRoom: RoomId,
+  toRoom: RoomId,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
+): number {
+  const from = roomMap[fromRoom].center
+  const to = roomMap[toRoom].center
 
   const dx = to.x - from.x
   const dz = to.z - from.z
@@ -339,12 +361,15 @@ export function getFacingAngle(fromRoom: RoomId, toRoom: RoomId): number {
  * as adjacent, then B should also list A.
  * Returns an array of asymmetry descriptions (empty = valid graph).
  */
-export function validateAdjacencyGraph(): string[] {
+export function validateAdjacencyGraph(
+  rooms: readonly Room[] = ROOMS,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
+): string[] {
   const errors: string[] = []
 
-  for (const room of ROOMS) {
+  for (const room of rooms) {
     for (const neighbor of room.adjacentRooms) {
-      const neighborRoom = ROOM_MAP[neighbor]
+      const neighborRoom = roomMap[neighbor]
       if (!neighborRoom) {
         errors.push(`Room ${room.id} lists unknown neighbor: ${neighbor}`)
         continue

--- a/src/game/character/schedule.ts
+++ b/src/game/character/schedule.ts
@@ -8,7 +8,7 @@
 //   3. Personality bias (weights preferred activities)
 //   4. Semi-deterministic randomness (seeded from name + day + hour)
 
-import type { RoomId, ActivityType } from '../rooms'
+import type { RoomId, ActivityType, Room } from '../rooms'
 import { ROOM_MAP } from '../rooms'
 import type { Needs } from './needs'
 import { getMostUrgentNeed, getCriticalNeeds, CRITICAL_NEED_THRESHOLD } from './needs'
@@ -254,6 +254,7 @@ export function selectNextActivity(
   hobbyType: HobbyType,
   currentRoom: RoomId,
   characterName: string,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
 ): ActivitySelection {
   // 1. Check for critical needs override
   const criticalNeeds = getCriticalNeeds(needs)
@@ -286,7 +287,7 @@ export function selectNextActivity(
 
   // Filter candidates to only rooms where their activities are actually available
   const viableCandidates = slot.candidates.filter((c) => {
-    const room = ROOM_MAP[c.room]
+    const room = roomMap[c.room]
     return room.activities.includes(c.activity)
   })
 
@@ -338,7 +339,10 @@ export function selectNextActivity(
  * When a character name is provided, picks a random room and valid activity
  * so each page load feels different.
  */
-export function getInitialActivity(characterName?: string): ActivitySelection {
+export function getInitialActivity(
+  characterName?: string,
+  roomMap: Readonly<Record<RoomId, Room>> = ROOM_MAP,
+): ActivitySelection {
   if (!characterName) {
     return { room: 'living_room', activity: 'idle', durationHours: 0.25 }
   }
@@ -353,7 +357,7 @@ export function getInitialActivity(characterName?: string): ActivitySelection {
   // different room on each visit
   const rng = seededRngFromKey(`${characterName}:start:${Math.random()}`)
   const room = rng.pick(startableRooms)
-  const roomDef = ROOM_MAP[room]
+  const roomDef = roomMap[room]
   const activity = rng.pick(roomDef.activities)
 
   return { room, activity, durationHours: 0.25 }

--- a/src/game/house.ts
+++ b/src/game/house.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three'
 import { PALETTE } from './palette'
 import type { Vec3, Room, VoxelSpec } from './types'
+import type { HouseLayout, LayoutRoomId, RoomSlot } from '@/lib/layout'
 
 // ---------------------------------------------------------------------------
 // House constants
@@ -128,10 +129,14 @@ function buildFloorShell(
 }
 
 // ---------------------------------------------------------------------------
-// Interior room divider walls
+// Interior room divider walls — layout-driven
 // ---------------------------------------------------------------------------
 
-function buildInteriorWalls(group: THREE.Group, floor: 1 | 2 | 3): void {
+function buildInteriorWalls(
+  group: THREE.Group,
+  floor: 1 | 2 | 3,
+  wallXPositions: number[],
+): void {
   const baseY = floorY(floor)
   const hd = HOUSE_DEPTH
   const wallH = FLOOR_HEIGHT - 1
@@ -140,7 +145,7 @@ function buildInteriorWalls(group: THREE.Group, floor: 1 | 2 | 3): void {
   const wallZCenter = (hd - 1) / 2  // 3.5
   const wallZSize = hd - 1           // 7
 
-  // Staircase divider wall (shared by all floors)
+  // Staircase divider wall (shared by all floors, always at x=27)
   group.add(
     makeVoxel(
       { x: STAIR_X_START + 0.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
@@ -150,49 +155,11 @@ function buildInteriorWalls(group: THREE.Group, floor: 1 | 2 | 3): void {
     ),
   )
 
-  if (floor === 1) {
-    // Entry / living room divider at x=4
+  // Dynamic interior walls from layout
+  for (const wallX of wallXPositions) {
     group.add(
       makeVoxel(
-        { x: 4.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
-        PALETTE.WALL_INTERIOR,
-        { x: wt, y: wallH, z: wallZSize },
-        true,
-      ),
-    )
-    // Living room / kitchen divider at x=16
-    group.add(
-      makeVoxel(
-        { x: 16.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
-        PALETTE.WALL_INTERIOR,
-        { x: wt, y: wallH, z: wallZSize },
-        true,
-      ),
-    )
-  } else if (floor === 2) {
-    // Bedroom / bathroom divider at x=14
-    group.add(
-      makeVoxel(
-        { x: 14.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
-        PALETTE.WALL_INTERIOR,
-        { x: wt, y: wallH, z: wallZSize },
-        true,
-      ),
-    )
-    // Bathroom / study divider at x=20
-    group.add(
-      makeVoxel(
-        { x: 20.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
-        PALETTE.WALL_INTERIOR,
-        { x: wt, y: wallH, z: wallZSize },
-        true,
-      ),
-    )
-  } else if (floor === 3) {
-    // Music room / library divider at x=16
-    group.add(
-      makeVoxel(
-        { x: 16.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
+        { x: wallX + 0.5, y: baseY + wallH / 2 + 1, z: wallZCenter },
         PALETTE.WALL_INTERIOR,
         { x: wt, y: wallH, z: wallZSize },
         true,
@@ -202,265 +169,374 @@ function buildInteriorWalls(group: THREE.Group, floor: 1 | 2 | 3): void {
 }
 
 // ---------------------------------------------------------------------------
-// Furniture builders per room
+// Furniture builders — parameterized by (group, xMin, xMax, floor)
+//
+// Each room builder places furniture using anchor-based positioning:
+//   cx = center of room, xMin/xMax = edges, ft = floor top surface Y
+// Furniture sizes are unchanged; only positions adapt to room bounds.
+// Non-essential furniture is conditionally omitted when room is too narrow.
 // ---------------------------------------------------------------------------
 
-// Floor 1: Entry Hall (x=1..4)
-function buildEntranceHall(group: THREE.Group): void {
-  const baseY = floorY(1)
-  const ft = baseY + 1
+function buildEntranceRoom(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
 
   addVoxels(group, [
-    // Front door frame on back wall
-    { position: { x: 2.5, y: ft + 2, z: 7.5 }, color: PALETTE.DOOR, size: { x: 2, y: 4, z: 0.5 } },
-    // Coat rack
-    { position: { x: 1.5, y: ft + 2, z: 5 }, color: PALETTE.BOOKSHELF, size: { x: 0.5, y: 4, z: 0.5 } },
-    // Coat rack hooks (small horizontal protrusions)
-    { position: { x: 1.75, y: ft + 3, z: 4.8 }, color: PALETTE.DESK, size: { x: 0.5, y: 0.5, z: 0.4 } },
-    { position: { x: 1.75, y: ft + 2, z: 4.8 }, color: PALETTE.DESK, size: { x: 0.5, y: 0.5, z: 0.4 } },
-    // Entry rug (thin flat slab)
-    { position: { x: 2.5, y: ft + 0.1, z: 4 }, color: PALETTE.SOFA, size: { x: 2, y: 0.1, z: 3 } },
+    // Front door frame on back wall — centered
+    { position: { x: cx, y: ft + 2, z: 7.5 }, color: PALETTE.DOOR, size: { x: 2, y: 4, z: 0.5 } },
+    // Coat rack — left side
+    { position: { x: xMin + 0.5, y: ft + 2, z: 5 }, color: PALETTE.BOOKSHELF, size: { x: 0.5, y: 4, z: 0.5 } },
+    // Coat rack hooks
+    { position: { x: xMin + 0.75, y: ft + 3, z: 4.8 }, color: PALETTE.DESK, size: { x: 0.5, y: 0.5, z: 0.4 } },
+    { position: { x: xMin + 0.75, y: ft + 2, z: 4.8 }, color: PALETTE.DESK, size: { x: 0.5, y: 0.5, z: 0.4 } },
+    // Entry rug — centered
+    { position: { x: cx, y: ft + 0.1, z: 4 }, color: PALETTE.SOFA, size: { x: 2, y: 0.1, z: 3 } },
   ])
 }
 
-// Floor 1: Living Room (x=4..16)
-function buildLivingRoom(group: THREE.Group): void {
-  const baseY = floorY(1)
-  const ft = baseY + 1
+function buildLivingRoomFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
 
-  addVoxels(group, [
-    // Sofa — wide 3-seater
-    { position: { x: 8, y: ft + 0.5, z: 6.5 }, color: PALETTE.SOFA, size: { x: 5, y: 1, z: 1.5 } },
-    { position: { x: 8, y: ft + 1.5, z: 7.2 }, color: PALETTE.SOFA, size: { x: 5, y: 2, z: 0.5 } },
-    // Sofa cushions (accent)
-    { position: { x: 7, y: ft + 1, z: 6 }, color: PALETTE.BED, size: { x: 1, y: 0.5, z: 1 } },
-    { position: { x: 9, y: ft + 1, z: 6 }, color: PALETTE.BED, size: { x: 1, y: 0.5, z: 1 } },
-    // TV stand
-    { position: { x: 8, y: ft + 0.5, z: 1.5 }, color: PALETTE.DESK, size: { x: 4, y: 1, z: 1 } },
+  const specs: VoxelSpec[] = [
+    // Sofa — centered, back area
+    { position: { x: cx, y: ft + 0.5, z: 6.5 }, color: PALETTE.SOFA, size: { x: 5, y: 1, z: 1.5 } },
+    { position: { x: cx, y: ft + 1.5, z: 7.2 }, color: PALETTE.SOFA, size: { x: 5, y: 2, z: 0.5 } },
+    // Sofa cushions
+    { position: { x: cx - 1, y: ft + 1, z: 6 }, color: PALETTE.BED, size: { x: 1, y: 0.5, z: 1 } },
+    { position: { x: cx + 1, y: ft + 1, z: 6 }, color: PALETTE.BED, size: { x: 1, y: 0.5, z: 1 } },
+    // TV stand — centered, front
+    { position: { x: cx, y: ft + 0.5, z: 1.5 }, color: PALETTE.DESK, size: { x: 4, y: 1, z: 1 } },
     // TV screen
-    { position: { x: 8, y: ft + 1.75, z: 1.6 }, color: PALETTE.TV_SCREEN, size: { x: 3.5, y: 2, z: 0.3 } },
-    // Fireplace (right side of living room, near divider)
-    { position: { x: 14.5, y: ft + 1.5, z: 7.5 }, color: PALETTE.STOVE, size: { x: 2, y: 3, z: 1 } },
-    // Fireplace mantel
-    { position: { x: 14.5, y: ft + 3, z: 7.2 }, color: PALETTE.STAIRCASE, size: { x: 3, y: 0.5, z: 1.5 } },
-    // Fire glow (orange block inside fireplace)
-    { position: { x: 14.5, y: ft + 0.5, z: 7.3 }, color: 0xe05c1a, size: { x: 1.2, y: 1, z: 0.5 } },
-    // Armchair
-    { position: { x: 12, y: ft + 0.5, z: 5 }, color: PALETTE.SOFA, size: { x: 1.5, y: 1, z: 1.5 } },
-    { position: { x: 12, y: ft + 1.5, z: 5.7 }, color: PALETTE.SOFA, size: { x: 1.5, y: 1.5, z: 0.5 } },
-    // Coffee table
-    { position: { x: 8, y: ft + 0.5, z: 4.5 }, color: PALETTE.TABLE, size: { x: 3, y: 0.5, z: 1.5 } },
-    // Bookshelf (left side)
-    { position: { x: 5.5, y: ft + 2, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 2, y: 4, z: 0.5 } },
-    // Books on shelf (color accents)
-    { position: { x: 5, y: ft + 1, z: 7.4 }, color: 0x8b3a3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 5.5, y: ft + 2, z: 7.4 }, color: 0x3a6b3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 6, y: ft + 3, z: 7.4 }, color: 0x3a3a8b, size: { x: 0.5, y: 1, z: 0.3 } },
-    // Lamp
-    { position: { x: 6, y: ft + 1, z: 4.5 }, color: PALETTE.FRIDGE, size: { x: 0.3, y: 2, z: 0.3 } },
-    { position: { x: 6, y: ft + 2.2, z: 4.5 }, color: 0xfff4c0, size: { x: 0.8, y: 0.4, z: 0.8 } },
-  ])
+    { position: { x: cx, y: ft + 1.75, z: 1.6 }, color: PALETTE.TV_SCREEN, size: { x: 3.5, y: 2, z: 0.3 } },
+    // Coffee table — centered
+    { position: { x: cx, y: ft + 0.5, z: 4.5 }, color: PALETTE.TABLE, size: { x: 3, y: 0.5, z: 1.5 } },
+    // Bookshelf — left side, back wall
+    { position: { x: xMin + 1.5, y: ft + 2, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 2, y: 4, z: 0.5 } },
+    // Books on shelf
+    { position: { x: xMin + 1, y: ft + 1, z: 7.4 }, color: 0x8b3a3a, size: { x: 0.5, y: 1, z: 0.3 } },
+    { position: { x: xMin + 1.5, y: ft + 2, z: 7.4 }, color: 0x3a6b3a, size: { x: 0.5, y: 1, z: 0.3 } },
+    { position: { x: xMin + 2, y: ft + 3, z: 7.4 }, color: 0x3a3a8b, size: { x: 0.5, y: 1, z: 0.3 } },
+    // Lamp — left side
+    { position: { x: xMin + 2, y: ft + 1, z: 4.5 }, color: PALETTE.FRIDGE, size: { x: 0.3, y: 2, z: 0.3 } },
+    { position: { x: xMin + 2, y: ft + 2.2, z: 4.5 }, color: 0xfff4c0, size: { x: 0.8, y: 0.4, z: 0.8 } },
+  ]
+
+  // Fireplace + armchair — right side (only if room is wide enough)
+  if (w >= 10) {
+    specs.push(
+      // Fireplace
+      { position: { x: xMax - 1.5, y: ft + 1.5, z: 7.5 }, color: PALETTE.STOVE, size: { x: 2, y: 3, z: 1 } },
+      { position: { x: xMax - 1.5, y: ft + 3, z: 7.2 }, color: PALETTE.STAIRCASE, size: { x: 3, y: 0.5, z: 1.5 } },
+      { position: { x: xMax - 1.5, y: ft + 0.5, z: 7.3 }, color: 0xe05c1a, size: { x: 1.2, y: 1, z: 0.5 } },
+      // Armchair
+      { position: { x: cx + 2, y: ft + 0.5, z: 5 }, color: PALETTE.SOFA, size: { x: 1.5, y: 1, z: 1.5 } },
+      { position: { x: cx + 2, y: ft + 1.5, z: 5.7 }, color: PALETTE.SOFA, size: { x: 1.5, y: 1.5, z: 0.5 } },
+    )
+  }
+
+  addVoxels(group, specs)
 }
 
-// Floor 1: Kitchen (x=16..27)
-function buildKitchen(group: THREE.Group): void {
-  const baseY = floorY(1)
-  const ft = baseY + 1
+function buildKitchenFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
+  const counterW = Math.min(w - 2, 9)
 
-  addVoxels(group, [
-    // Counter along back wall
-    { position: { x: 22.5, y: ft + 0.5, z: 7.5 }, color: PALETTE.COUNTER, size: { x: 9, y: 1, z: 1 } },
+  const specs: VoxelSpec[] = [
+    // Counter along back wall — centered
+    { position: { x: cx, y: ft + 0.5, z: 7.5 }, color: PALETTE.COUNTER, size: { x: counterW, y: 1, z: 1 } },
     // Counter backsplash
-    { position: { x: 22.5, y: ft + 2, z: 7.8 }, color: 0xd0e8e8, size: { x: 9, y: 2, z: 0.3 } },
-    // Stove (on counter, left side)
-    { position: { x: 18.5, y: ft + 1.5, z: 7.3 }, color: PALETTE.STOVE, size: { x: 2, y: 1, z: 0.7 } },
+    { position: { x: cx, y: ft + 2, z: 7.8 }, color: 0xd0e8e8, size: { x: counterW, y: 2, z: 0.3 } },
+    // Stove — left side of counter
+    { position: { x: xMin + 2.5, y: ft + 1.5, z: 7.3 }, color: PALETTE.STOVE, size: { x: 2, y: 1, z: 0.7 } },
     // Stove top burners
-    { position: { x: 18, y: ft + 2, z: 7.2 }, color: 0x444444, size: { x: 0.7, y: 0.3, z: 0.7 } },
-    { position: { x: 19, y: ft + 2, z: 7.2 }, color: 0x444444, size: { x: 0.7, y: 0.3, z: 0.7 } },
-    // Sink (on counter, center)
-    { position: { x: 22.5, y: ft + 1.5, z: 7.3 }, color: PALETTE.FRIDGE, size: { x: 1.5, y: 0.7, z: 0.7 } },
-    // Fridge (tall, right of counter)
-    { position: { x: 25.5, y: ft + 2, z: 7 }, color: PALETTE.FRIDGE, size: { x: 1.5, y: 4, z: 1.5 } },
+    { position: { x: xMin + 2, y: ft + 2, z: 7.2 }, color: 0x444444, size: { x: 0.7, y: 0.3, z: 0.7 } },
+    { position: { x: xMin + 3, y: ft + 2, z: 7.2 }, color: 0x444444, size: { x: 0.7, y: 0.3, z: 0.7 } },
+    // Sink — center of counter
+    { position: { x: cx, y: ft + 1.5, z: 7.3 }, color: PALETTE.FRIDGE, size: { x: 1.5, y: 0.7, z: 0.7 } },
+    // Fridge — right side
+    { position: { x: xMax - 1.5, y: ft + 2, z: 7 }, color: PALETTE.FRIDGE, size: { x: 1.5, y: 4, z: 1.5 } },
     // Fridge handle
-    { position: { x: 24.9, y: ft + 2, z: 7 }, color: PALETTE.STOVE, size: { x: 0.2, y: 2, z: 0.3 } },
-    // Dining table
-    { position: { x: 21, y: ft + 0.5, z: 4.5 }, color: PALETTE.TABLE, size: { x: 4, y: 1, z: 2.5 } },
-    // Table leg detail
-    { position: { x: 19.5, y: ft + 0.5, z: 3.5 }, color: PALETTE.DESK, size: { x: 0.3, y: 1, z: 0.3 } },
-    { position: { x: 22.5, y: ft + 0.5, z: 3.5 }, color: PALETTE.DESK, size: { x: 0.3, y: 1, z: 0.3 } },
+    { position: { x: xMax - 2.1, y: ft + 2, z: 7 }, color: PALETTE.STOVE, size: { x: 0.2, y: 2, z: 0.3 } },
+    // Dining table — centered
+    { position: { x: cx, y: ft + 0.5, z: 4.5 }, color: PALETTE.TABLE, size: { x: 4, y: 1, z: 2.5 } },
+    // Table legs
+    { position: { x: cx - 1.5, y: ft + 0.5, z: 3.5 }, color: PALETTE.DESK, size: { x: 0.3, y: 1, z: 0.3 } },
+    { position: { x: cx + 1.5, y: ft + 0.5, z: 3.5 }, color: PALETTE.DESK, size: { x: 0.3, y: 1, z: 0.3 } },
     // Chairs
-    { position: { x: 19.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.WARDROBE, size: { x: 1, y: 1, z: 1 } },
-    { position: { x: 22.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.WARDROBE, size: { x: 1, y: 1, z: 1 } },
-    // Upper cabinet
-    { position: { x: 20, y: ft + 4.5, z: 7.6 }, color: PALETTE.COUNTER, size: { x: 4, y: 2, z: 0.7 } },
-  ])
+    { position: { x: cx - 1.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.WARDROBE, size: { x: 1, y: 1, z: 1 } },
+    { position: { x: cx + 1.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.WARDROBE, size: { x: 1, y: 1, z: 1 } },
+  ]
+
+  // Upper cabinet (only if wide enough)
+  if (w >= 8) {
+    specs.push(
+      { position: { x: xMin + 4, y: ft + 4.5, z: 7.6 }, color: PALETTE.COUNTER, size: { x: 4, y: 2, z: 0.7 } },
+    )
+  }
+
+  addVoxels(group, specs)
 }
 
-// Floor 2: Bedroom (x=1..14)
-function buildBedroom(group: THREE.Group): void {
-  const baseY = floorY(2)
-  const ft = baseY + 1
+function buildBedroomFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
 
-  addVoxels(group, [
-    // Bed (wide double bed)
-    { position: { x: 5.5, y: ft + 0.5, z: 6.5 }, color: PALETTE.BED, size: { x: 5, y: 1, z: 2 } },
-    // Duvet / blanket
-    { position: { x: 5.5, y: ft + 1, z: 6.5 }, color: 0xb8a0cc, size: { x: 4.5, y: 0.3, z: 2 } },
+  const specs: VoxelSpec[] = [
+    // Bed — centered, back area
+    { position: { x: cx, y: ft + 0.5, z: 6.5 }, color: PALETTE.BED, size: { x: 5, y: 1, z: 2 } },
+    // Duvet
+    { position: { x: cx, y: ft + 1, z: 6.5 }, color: 0xb8a0cc, size: { x: 4.5, y: 0.3, z: 2 } },
     // Pillows
-    { position: { x: 4, y: ft + 1, z: 5.7 }, color: PALETTE.CEILING, size: { x: 1.5, y: 0.5, z: 0.8 } },
-    { position: { x: 6.5, y: ft + 1, z: 5.7 }, color: PALETTE.CEILING, size: { x: 1.5, y: 0.5, z: 0.8 } },
-    // Bed headboard
-    { position: { x: 5.5, y: ft + 2, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 5.5, y: 3, z: 0.5 } },
-    // Nightstand (left side)
-    { position: { x: 2.5, y: ft + 0.5, z: 6.5 }, color: PALETTE.DESK, size: { x: 1.5, y: 1, z: 1.5 } },
-    // Bedside lamp
-    { position: { x: 2.5, y: ft + 1.5, z: 6.5 }, color: PALETTE.FRIDGE, size: { x: 0.3, y: 1, z: 0.3 } },
-    { position: { x: 2.5, y: ft + 2.1, z: 6.5 }, color: 0xfff4c0, size: { x: 0.7, y: 0.3, z: 0.7 } },
-    // Wardrobe (double, against back wall left)
-    { position: { x: 2, y: ft + 2.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 3, y: 5, z: 0.8 } },
-    // Wardrobe door detail
-    { position: { x: 1.5, y: ft + 2.5, z: 7.2 }, color: PALETTE.DESK, size: { x: 1, y: 4, z: 0.3 } },
-    { position: { x: 2.5, y: ft + 2.5, z: 7.2 }, color: PALETTE.DESK, size: { x: 1, y: 4, z: 0.3 } },
-    // Dresser (against back wall right)
-    { position: { x: 11, y: ft + 0.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 4, y: 1, z: 1 } },
-    { position: { x: 11, y: ft + 1.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 4, y: 1, z: 1 } },
-    // Dresser drawer handles
-    { position: { x: 10, y: ft + 0.5, z: 7.1 }, color: PALETTE.FRIDGE, size: { x: 0.8, y: 0.3, z: 0.3 } },
-    { position: { x: 12, y: ft + 0.5, z: 7.1 }, color: PALETTE.FRIDGE, size: { x: 0.8, y: 0.3, z: 0.3 } },
-    // Rug
-    { position: { x: 6, y: ft + 0.1, z: 4.5 }, color: 0x7a5cb8, size: { x: 7, y: 0.1, z: 3 } },
-  ])
+    { position: { x: cx - 1.5, y: ft + 1, z: 5.7 }, color: PALETTE.CEILING, size: { x: 1.5, y: 0.5, z: 0.8 } },
+    { position: { x: cx + 1, y: ft + 1, z: 5.7 }, color: PALETTE.CEILING, size: { x: 1.5, y: 0.5, z: 0.8 } },
+    // Headboard — centered, back wall
+    { position: { x: cx, y: ft + 2, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 5.5, y: 3, z: 0.5 } },
+    // Rug — centered
+    { position: { x: cx, y: ft + 0.1, z: 4.5 }, color: 0x7a5cb8, size: { x: Math.min(7, w - 2), y: 0.1, z: 3 } },
+  ]
+
+  // Nightstand + lamp (left of bed)
+  if (w >= 8) {
+    specs.push(
+      { position: { x: xMin + 1.5, y: ft + 0.5, z: 6.5 }, color: PALETTE.DESK, size: { x: 1.5, y: 1, z: 1.5 } },
+      { position: { x: xMin + 1.5, y: ft + 1.5, z: 6.5 }, color: PALETTE.FRIDGE, size: { x: 0.3, y: 1, z: 0.3 } },
+      { position: { x: xMin + 1.5, y: ft + 2.1, z: 6.5 }, color: 0xfff4c0, size: { x: 0.7, y: 0.3, z: 0.7 } },
+    )
+  }
+
+  // Wardrobe (left side, back wall)
+  if (w >= 8) {
+    specs.push(
+      { position: { x: xMin + 1.5, y: ft + 2.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 3, y: 5, z: 0.8 } },
+      { position: { x: xMin + 1, y: ft + 2.5, z: 7.2 }, color: PALETTE.DESK, size: { x: 1, y: 4, z: 0.3 } },
+      { position: { x: xMin + 2, y: ft + 2.5, z: 7.2 }, color: PALETTE.DESK, size: { x: 1, y: 4, z: 0.3 } },
+    )
+  }
+
+  // Dresser (right side, back wall)
+  if (w >= 10) {
+    specs.push(
+      { position: { x: xMax - 3, y: ft + 0.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 4, y: 1, z: 1 } },
+      { position: { x: xMax - 3, y: ft + 1.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 4, y: 1, z: 1 } },
+      { position: { x: xMax - 4, y: ft + 0.5, z: 7.1 }, color: PALETTE.FRIDGE, size: { x: 0.8, y: 0.3, z: 0.3 } },
+      { position: { x: xMax - 2, y: ft + 0.5, z: 7.1 }, color: PALETTE.FRIDGE, size: { x: 0.8, y: 0.3, z: 0.3 } },
+    )
+  }
+
+  addVoxels(group, specs)
 }
 
-// Floor 2: Bathroom (x=14..20)
-function buildBathroom(group: THREE.Group): void {
-  const baseY = floorY(2)
-  const ft = baseY + 1
+function buildBathroomFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
 
   addVoxels(group, [
     // Floor tiles
-    { position: { x: 17, y: ft - 0.4, z: 4 }, color: PALETTE.TILE, size: { x: 6, y: 0.1, z: 6 } },
-    // Bathtub
-    { position: { x: 16.5, y: ft + 0.5, z: 6.5 }, color: PALETTE.PORCELAIN, size: { x: 4, y: 1, z: 2 } },
-    { position: { x: 16.5, y: ft + 0.9, z: 6.5 }, color: PALETTE.TILE, size: { x: 3, y: 0.5, z: 1.5 } },
-    // Bath tap
-    { position: { x: 15.3, y: ft + 1.5, z: 7 }, color: PALETTE.CHROME, size: { x: 0.3, y: 0.7, z: 0.3 } },
-    // Sink
-    { position: { x: 15.5, y: ft + 1, z: 2.5 }, color: PALETTE.PORCELAIN, size: { x: 1.5, y: 0.5, z: 1 } },
+    { position: { x: cx, y: ft - 0.4, z: 4 }, color: PALETTE.TILE, size: { x: w, y: 0.1, z: 6 } },
+    // Bathtub — centered, back area
+    { position: { x: cx, y: ft + 0.5, z: 6.5 }, color: PALETTE.PORCELAIN, size: { x: 4, y: 1, z: 2 } },
+    { position: { x: cx, y: ft + 0.9, z: 6.5 }, color: PALETTE.TILE, size: { x: 3, y: 0.5, z: 1.5 } },
+    // Bath tap — left end of tub
+    { position: { x: xMin + 1.3, y: ft + 1.5, z: 7 }, color: PALETTE.CHROME, size: { x: 0.3, y: 0.7, z: 0.3 } },
+    // Sink — left, front
+    { position: { x: xMin + 1.5, y: ft + 1, z: 2.5 }, color: PALETTE.PORCELAIN, size: { x: 1.5, y: 0.5, z: 1 } },
     // Sink pedestal
-    { position: { x: 15.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.PORCELAIN, size: { x: 0.8, y: 1, z: 0.8 } },
-    // Toilet
-    { position: { x: 18.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.PORCELAIN, size: { x: 1.5, y: 1, z: 1.5 } },
-    { position: { x: 18.5, y: ft + 1, z: 3.2 }, color: PALETTE.PORCELAIN, size: { x: 1.5, y: 0.5, z: 0.8 } },
-    // Mirror above sink
-    { position: { x: 15.5, y: ft + 3, z: 7.6 }, color: 0xc0d8e8, size: { x: 2, y: 2, z: 0.3 } },
-    // Towel rail
-    { position: { x: 18, y: ft + 2.5, z: 7.6 }, color: PALETTE.CHROME, size: { x: 2, y: 0.3, z: 0.3 } },
-    // Towel (on rail)
-    { position: { x: 18, y: ft + 1.5, z: 7.3 }, color: 0x4a9b9b, size: { x: 1.5, y: 2, z: 0.3 } },
+    { position: { x: xMin + 1.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.PORCELAIN, size: { x: 0.8, y: 1, z: 0.8 } },
+    // Toilet — right, front
+    { position: { x: xMax - 1.5, y: ft + 0.5, z: 2.5 }, color: PALETTE.PORCELAIN, size: { x: 1.5, y: 1, z: 1.5 } },
+    { position: { x: xMax - 1.5, y: ft + 1, z: 3.2 }, color: PALETTE.PORCELAIN, size: { x: 1.5, y: 0.5, z: 0.8 } },
+    // Mirror above sink — back wall
+    { position: { x: xMin + 1.5, y: ft + 3, z: 7.6 }, color: 0xc0d8e8, size: { x: 2, y: 2, z: 0.3 } },
+    // Towel rail — right side, back wall
+    { position: { x: xMax - 2, y: ft + 2.5, z: 7.6 }, color: PALETTE.CHROME, size: { x: 2, y: 0.3, z: 0.3 } },
+    // Towel
+    { position: { x: xMax - 2, y: ft + 1.5, z: 7.3 }, color: 0x4a9b9b, size: { x: 1.5, y: 2, z: 0.3 } },
   ])
 }
 
-// Floor 2: Study (x=20..27)
-function buildStudy(group: THREE.Group): void {
-  const baseY = floorY(2)
-  const ft = baseY + 1
+function buildStudyFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
 
-  addVoxels(group, [
-    // Desk (L-shaped: main desk + side return)
-    { position: { x: 23, y: ft + 0.5, z: 7 }, color: PALETTE.DESK, size: { x: 5, y: 1, z: 2 } },
-    { position: { x: 21, y: ft + 0.5, z: 5.5 }, color: PALETTE.DESK, size: { x: 1.5, y: 1, z: 1 } },
+  const specs: VoxelSpec[] = [
+    // Desk — centered, back wall
+    { position: { x: cx, y: ft + 0.5, z: 7 }, color: PALETTE.DESK, size: { x: 5, y: 1, z: 2 } },
+    // Desk side return — left
+    { position: { x: xMin + 1, y: ft + 0.5, z: 5.5 }, color: PALETTE.DESK, size: { x: 1.5, y: 1, z: 1 } },
     // Computer monitor
-    { position: { x: 22.5, y: ft + 1.75, z: 7.3 }, color: PALETTE.TV_SCREEN, size: { x: 2, y: 1.5, z: 0.3 } },
+    { position: { x: cx - 1, y: ft + 1.75, z: 7.3 }, color: PALETTE.TV_SCREEN, size: { x: 2, y: 1.5, z: 0.3 } },
     // Keyboard
-    { position: { x: 22.5, y: ft + 1, z: 6.4 }, color: PALETTE.STOVE, size: { x: 2, y: 0.2, z: 0.8 } },
+    { position: { x: cx - 1, y: ft + 1, z: 6.4 }, color: PALETTE.STOVE, size: { x: 2, y: 0.2, z: 0.8 } },
     // Desk chair
-    { position: { x: 23, y: ft + 0.5, z: 5 }, color: PALETTE.SOFA, size: { x: 1.5, y: 1, z: 1.5 } },
-    { position: { x: 23, y: ft + 1.5, z: 5.7 }, color: PALETTE.SOFA, size: { x: 1.5, y: 2, z: 0.5 } },
-    // Tall bookshelf (left side)
-    { position: { x: 21, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 2, y: 5, z: 0.8 } },
-    // Book spines (color accents)
-    { position: { x: 20.5, y: ft + 1, z: 7.2 }, color: 0x8b3a3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 21, y: ft + 2, z: 7.2 }, color: 0x3a5a8b, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 21.5, y: ft + 3.5, z: 7.2 }, color: 0x3a8b3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    // Tall bookshelf (right side)
-    { position: { x: 25.5, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 2, y: 5, z: 0.8 } },
-    // More book accents
-    { position: { x: 25, y: ft + 1, z: 7.2 }, color: 0x8b6a3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 26, y: ft + 2.5, z: 7.2 }, color: 0x6a3a8b, size: { x: 0.5, y: 1, z: 0.3 } },
+    { position: { x: cx, y: ft + 0.5, z: 5 }, color: PALETTE.SOFA, size: { x: 1.5, y: 1, z: 1.5 } },
+    { position: { x: cx, y: ft + 1.5, z: 5.7 }, color: PALETTE.SOFA, size: { x: 1.5, y: 2, z: 0.5 } },
+    // Left bookshelf
+    { position: { x: xMin + 1, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 2, y: 5, z: 0.8 } },
+    // Book spines (left)
+    { position: { x: xMin + 0.5, y: ft + 1, z: 7.2 }, color: 0x8b3a3a, size: { x: 0.5, y: 1, z: 0.3 } },
+    { position: { x: xMin + 1, y: ft + 2, z: 7.2 }, color: 0x3a5a8b, size: { x: 0.5, y: 1, z: 0.3 } },
+    { position: { x: xMin + 1.5, y: ft + 3.5, z: 7.2 }, color: 0x3a8b3a, size: { x: 0.5, y: 1, z: 0.3 } },
     // Desk lamp
-    { position: { x: 24.5, y: ft + 1, z: 6.5 }, color: PALETTE.BOOKSHELF, size: { x: 0.2, y: 2, z: 0.2 } },
-    { position: { x: 24.5, y: ft + 2.2, z: 6.3 }, color: 0xfff4c0, size: { x: 0.7, y: 0.3, z: 0.7 } },
-  ])
+    { position: { x: cx + 1.5, y: ft + 1, z: 6.5 }, color: PALETTE.BOOKSHELF, size: { x: 0.2, y: 2, z: 0.2 } },
+    { position: { x: cx + 1.5, y: ft + 2.2, z: 6.3 }, color: 0xfff4c0, size: { x: 0.7, y: 0.3, z: 0.7 } },
+  ]
+
+  // Right bookshelf (only if wide enough)
+  if (w >= 7) {
+    specs.push(
+      { position: { x: xMax - 1.5, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 2, y: 5, z: 0.8 } },
+      { position: { x: xMax - 2, y: ft + 1, z: 7.2 }, color: 0x8b6a3a, size: { x: 0.5, y: 1, z: 0.3 } },
+      { position: { x: xMax - 1, y: ft + 2.5, z: 7.2 }, color: 0x6a3a8b, size: { x: 0.5, y: 1, z: 0.3 } },
+    )
+  }
+
+  addVoxels(group, specs)
 }
 
-// Floor 3: Music Room / Piano Room (x=1..16) — LCP-inspired
-function buildMusicRoom(group: THREE.Group): void {
-  const baseY = floorY(3)
-  const ft = baseY + 1
+function buildHobbyRoomFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
 
-  addVoxels(group, [
-    // Upright piano (against back-left wall)
-    { position: { x: 4, y: ft + 2, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 4, y: 4, z: 1 } },
-    // Piano keys (lighter strip on front)
-    { position: { x: 4, y: ft + 0.5, z: 7.1 }, color: PALETTE.CEILING, size: { x: 3.5, y: 0.5, z: 0.5 } },
-    // Piano black keys (dark accent)
-    { position: { x: 3.5, y: ft + 0.8, z: 6.9 }, color: PALETTE.TV_SCREEN, size: { x: 0.4, y: 0.4, z: 0.3 } },
-    { position: { x: 4.5, y: ft + 0.8, z: 6.9 }, color: PALETTE.TV_SCREEN, size: { x: 0.4, y: 0.4, z: 0.3 } },
+  const specs: VoxelSpec[] = [
+    // Upright piano — left side, back wall
+    { position: { x: xMin + 3, y: ft + 2, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 4, y: 4, z: 1 } },
+    // Piano keys
+    { position: { x: xMin + 3, y: ft + 0.5, z: 7.1 }, color: PALETTE.CEILING, size: { x: 3.5, y: 0.5, z: 0.5 } },
+    // Piano black keys
+    { position: { x: xMin + 2.5, y: ft + 0.8, z: 6.9 }, color: PALETTE.TV_SCREEN, size: { x: 0.4, y: 0.4, z: 0.3 } },
+    { position: { x: xMin + 3.5, y: ft + 0.8, z: 6.9 }, color: PALETTE.TV_SCREEN, size: { x: 0.4, y: 0.4, z: 0.3 } },
     // Piano bench
-    { position: { x: 4, y: ft + 0.5, z: 5.5 }, color: PALETTE.WARDROBE, size: { x: 2.5, y: 1, z: 1 } },
-    // Record player / stereo on cabinet
-    { position: { x: 10, y: ft + 0.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 3, y: 1, z: 1 } },
-    { position: { x: 10, y: ft + 1.5, z: 7.3 }, color: PALETTE.TV_SCREEN, size: { x: 2, y: 0.5, z: 0.5 } },
-    // Speakers (either side)
-    { position: { x: 7.5, y: ft + 1.5, z: 7.5 }, color: PALETTE.STOVE, size: { x: 1.5, y: 3, z: 1 } },
-    { position: { x: 12.5, y: ft + 1.5, z: 7.5 }, color: PALETTE.STOVE, size: { x: 1.5, y: 3, z: 1 } },
-    // Couch (center)
-    { position: { x: 8, y: ft + 0.5, z: 4.5 }, color: PALETTE.SOFA, size: { x: 4, y: 1, z: 1.5 } },
-    { position: { x: 8, y: ft + 1.5, z: 5.2 }, color: PALETTE.SOFA, size: { x: 4, y: 1.5, z: 0.5 } },
+    { position: { x: xMin + 3, y: ft + 0.5, z: 5.5 }, color: PALETTE.WARDROBE, size: { x: 2.5, y: 1, z: 1 } },
+    // Record player / stereo on cabinet — centered
+    { position: { x: cx, y: ft + 0.5, z: 7.5 }, color: PALETTE.WARDROBE, size: { x: 3, y: 1, z: 1 } },
+    { position: { x: cx, y: ft + 1.5, z: 7.3 }, color: PALETTE.TV_SCREEN, size: { x: 2, y: 0.5, z: 0.5 } },
+    // Couch — centered
+    { position: { x: cx, y: ft + 0.5, z: 4.5 }, color: PALETTE.SOFA, size: { x: 4, y: 1, z: 1.5 } },
+    { position: { x: cx, y: ft + 1.5, z: 5.2 }, color: PALETTE.SOFA, size: { x: 4, y: 1.5, z: 0.5 } },
     // Rug
-    { position: { x: 8, y: ft + 0.1, z: 4.5 }, color: 0x8b3a5a, size: { x: 6, y: 0.1, z: 4 } },
-    // Easel (right side, against back wall so character transit path doesn't clip it)
-    { position: { x: 14, y: ft + 2, z: 7 }, color: PALETTE.STAIRCASE, size: { x: 0.5, y: 4, z: 0.5 } },
-    { position: { x: 14, y: ft + 3, z: 6.5 }, color: PALETTE.CEILING, size: { x: 2, y: 2, z: 0.3 } },
-  ])
+    { position: { x: cx, y: ft + 0.1, z: 4.5 }, color: 0x8b3a5a, size: { x: Math.min(6, w - 2), y: 0.1, z: 4 } },
+  ]
+
+  // Speakers (only if wide enough)
+  if (w >= 10) {
+    specs.push(
+      { position: { x: cx - 2.5, y: ft + 1.5, z: 7.5 }, color: PALETTE.STOVE, size: { x: 1.5, y: 3, z: 1 } },
+      { position: { x: cx + 2.5, y: ft + 1.5, z: 7.5 }, color: PALETTE.STOVE, size: { x: 1.5, y: 3, z: 1 } },
+    )
+  }
+
+  // Easel — right side, back wall (only if wide enough)
+  if (w >= 8) {
+    specs.push(
+      { position: { x: xMax - 2, y: ft + 2, z: 7 }, color: PALETTE.STAIRCASE, size: { x: 0.5, y: 4, z: 0.5 } },
+      { position: { x: xMax - 2, y: ft + 3, z: 6.5 }, color: PALETTE.CEILING, size: { x: 2, y: 2, z: 0.3 } },
+    )
+  }
+
+  addVoxels(group, specs)
 }
 
-// Floor 3: Library (x=16..27)
-function buildLibrary(group: THREE.Group): void {
-  const baseY = floorY(3)
-  const ft = baseY + 1
+function buildStorageFurniture(
+  group: THREE.Group,
+  xMin: number,
+  xMax: number,
+  floor: 1 | 2 | 3,
+): void {
+  const ft = floorY(floor) + 1
+  const cx = (xMin + xMax) / 2
+  const w = xMax - xMin
 
-  addVoxels(group, [
-    // Three tall bookshelves across the back wall
-    { position: { x: 18, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 3, y: 5, z: 0.8 } },
-    { position: { x: 21.5, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 3, y: 5, z: 0.8 } },
-    { position: { x: 25, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 3, y: 5, z: 0.8 } },
-    // Book color accents on shelves
-    { position: { x: 17.5, y: ft + 1, z: 7.2 }, color: 0x8b3a3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 18.5, y: ft + 2, z: 7.2 }, color: 0x3a5a8b, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 19, y: ft + 3.5, z: 7.2 }, color: 0x3a8b3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 21, y: ft + 1.5, z: 7.2 }, color: 0x8b6a3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 22.5, y: ft + 3, z: 7.2 }, color: 0x6a3a8b, size: { x: 0.5, y: 1, z: 0.3 } },
-    { position: { x: 24.5, y: ft + 2, z: 7.2 }, color: 0x8b8b3a, size: { x: 0.5, y: 1, z: 0.3 } },
-    // Reading armchair
-    { position: { x: 19, y: ft + 0.5, z: 4.5 }, color: PALETTE.WARDROBE, size: { x: 2, y: 1, z: 2 } },
-    { position: { x: 19, y: ft + 1.5, z: 5.4 }, color: PALETTE.WARDROBE, size: { x: 2, y: 2, z: 0.5 } },
-    // Side table (with lamp)
-    { position: { x: 21, y: ft + 0.5, z: 4 }, color: PALETTE.DESK, size: { x: 1, y: 1, z: 1 } },
-    { position: { x: 21, y: ft + 1, z: 4 }, color: PALETTE.BOOKSHELF, size: { x: 0.2, y: 2, z: 0.2 } },
-    { position: { x: 21, y: ft + 2.1, z: 4 }, color: 0xfff4c0, size: { x: 0.8, y: 0.3, z: 0.8 } },
-    // Writing desk (right side)
-    { position: { x: 24.5, y: ft + 0.5, z: 4 }, color: PALETTE.DESK, size: { x: 3, y: 1, z: 1.5 } },
-    // Quill / pen pot
-    { position: { x: 25, y: ft + 1.2, z: 3.5 }, color: PALETTE.BOOKSHELF, size: { x: 0.4, y: 1, z: 0.4 } },
+  const specs: VoxelSpec[] = [
+    // Center bookshelf — back wall
+    { position: { x: cx, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 3, y: 5, z: 0.8 } },
+    // Book accents (center)
+    { position: { x: cx - 0.5, y: ft + 1.5, z: 7.2 }, color: 0x8b6a3a, size: { x: 0.5, y: 1, z: 0.3 } },
+    { position: { x: cx + 0.5, y: ft + 3, z: 7.2 }, color: 0x6a3a8b, size: { x: 0.5, y: 1, z: 0.3 } },
+    // Reading armchair — left-center
+    { position: { x: xMin + 3, y: ft + 0.5, z: 4.5 }, color: PALETTE.WARDROBE, size: { x: 2, y: 1, z: 2 } },
+    { position: { x: xMin + 3, y: ft + 1.5, z: 5.4 }, color: PALETTE.WARDROBE, size: { x: 2, y: 2, z: 0.5 } },
+    // Side table with lamp
+    { position: { x: cx - 0.5, y: ft + 0.5, z: 4 }, color: PALETTE.DESK, size: { x: 1, y: 1, z: 1 } },
+    { position: { x: cx - 0.5, y: ft + 1, z: 4 }, color: PALETTE.BOOKSHELF, size: { x: 0.2, y: 2, z: 0.2 } },
+    { position: { x: cx - 0.5, y: ft + 2.1, z: 4 }, color: 0xfff4c0, size: { x: 0.8, y: 0.3, z: 0.8 } },
     // Rug
-    { position: { x: 21.5, y: ft + 0.1, z: 4.5 }, color: 0x3a5a3a, size: { x: 8, y: 0.1, z: 5 } },
-  ])
+    { position: { x: cx, y: ft + 0.1, z: 4.5 }, color: 0x3a5a3a, size: { x: Math.min(8, w - 2), y: 0.1, z: 5 } },
+  ]
+
+  // Left bookshelf (if wide enough for 2+)
+  if (w >= 8) {
+    specs.push(
+      { position: { x: xMin + 2, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 3, y: 5, z: 0.8 } },
+      { position: { x: xMin + 1.5, y: ft + 1, z: 7.2 }, color: 0x8b3a3a, size: { x: 0.5, y: 1, z: 0.3 } },
+      { position: { x: xMin + 2.5, y: ft + 2, z: 7.2 }, color: 0x3a5a8b, size: { x: 0.5, y: 1, z: 0.3 } },
+      { position: { x: xMin + 3, y: ft + 3.5, z: 7.2 }, color: 0x3a8b3a, size: { x: 0.5, y: 1, z: 0.3 } },
+    )
+  }
+
+  // Right bookshelf (if wide enough for 3)
+  if (w >= 10) {
+    specs.push(
+      { position: { x: xMax - 2, y: ft + 2.5, z: 7.5 }, color: PALETTE.BOOKSHELF, size: { x: 3, y: 5, z: 0.8 } },
+      { position: { x: xMax - 2.5, y: ft + 2, z: 7.2 }, color: 0x8b8b3a, size: { x: 0.5, y: 1, z: 0.3 } },
+    )
+  }
+
+  // Writing desk (right side, if wide enough)
+  if (w >= 8) {
+    specs.push(
+      { position: { x: xMax - 2.5, y: ft + 0.5, z: 4 }, color: PALETTE.DESK, size: { x: 3, y: 1, z: 1.5 } },
+      { position: { x: xMax - 2, y: ft + 1.2, z: 3.5 }, color: PALETTE.BOOKSHELF, size: { x: 0.4, y: 1, z: 0.4 } },
+    )
+  }
+
+  addVoxels(group, specs)
 }
 
 // ---------------------------------------------------------------------------
-// Staircase builder
+// Staircase builder (always fixed position)
 // ---------------------------------------------------------------------------
 
 function buildStaircase(group: THREE.Group): void {
@@ -507,7 +583,27 @@ function buildStaircase(group: THREE.Group): void {
 // Room bounds registry
 // ---------------------------------------------------------------------------
 
-export function getRooms(): Room[] {
+export function getRooms(layout?: HouseLayout): Room[] {
+  if (layout) {
+    const rooms: Room[] = layout.slots.map((slot) => ({
+      id: (slot.roomId === 'entrance' ? 'entrance_hall' : slot.roomId) as Room['id'],
+      floor: slot.floor,
+      bounds: {
+        min: { x: slot.xMin, y: floorY(slot.floor), z: 1 },
+        max: { x: slot.xMax, y: floorY(slot.floor) + FLOOR_HEIGHT, z: HOUSE_DEPTH - 1 },
+      },
+    }))
+    rooms.push({
+      id: 'staircase',
+      floor: 1,
+      bounds: {
+        min: { x: STAIR_X_START, y: 0, z: 1 },
+        max: { x: HOUSE_WIDTH - 1, y: FLOOR_HEIGHT * FLOOR_COUNT, z: HOUSE_DEPTH - 1 },
+      },
+    })
+    return rooms
+  }
+
   return [
     {
       id: 'entrance_hall',
@@ -585,34 +681,30 @@ export function getRooms(): Room[] {
 }
 
 // ---------------------------------------------------------------------------
-// Main house builder
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Bathroom door — swings closed when character is inside
 // ---------------------------------------------------------------------------
 
 /**
  * Builds a bathroom door panel on a pivot group so it can swing open/closed.
- * Hinge is on the left edge (bedroom side). When closed (rotation.y = 0)
+ * The hinge is at the left edge of the bathroom slot. When closed (rotation.y = 0)
  * the panel covers the bathroom's front opening. When open (rotation.y = -PI/2)
- * the panel tucks alongside the bedroom-side wall, out of view.
+ * the panel tucks alongside the adjacent wall, out of view.
  */
-function buildBathroomDoor(): THREE.Group {
-  const baseY = floorY(2)
-  const wallH = FLOOR_HEIGHT - 1 // same as interior wall height
-  const doorWidth = 5.5           // from hinge (x=15) to study wall (x=20.5)
+function buildBathroomDoorForSlot(bathroomSlot: RoomSlot): THREE.Group {
+  const baseY = floorY(bathroomSlot.floor)
+  const wallH = FLOOR_HEIGHT - 1
+  const doorWidth = bathroomSlot.xMax - bathroomSlot.xMin - 0.5
   const doorThickness = 0.3
 
-  // Pivot group — positioned at the hinge point
+  // Pivot group — positioned at the hinge point (left edge of bathroom + 1)
   const pivot = new THREE.Group()
-  pivot.position.set(15, baseY + wallH / 2 + 1, 0.15)
+  pivot.position.set(bathroomSlot.xMin + 1, baseY + wallH / 2 + 1, 0.15)
 
   // Door panel — offset so its left edge sits at the pivot (hinge)
   const geo = new THREE.BoxGeometry(doorWidth, wallH, doorThickness)
   const mat = new THREE.MeshLambertMaterial({ color: PALETTE.DOOR })
   const panel = new THREE.Mesh(geo, mat)
-  panel.position.set(doorWidth / 2, 0, 0) // left edge at pivot
+  panel.position.set(doorWidth / 2, 0, 0)
   panel.castShadow = true
   panel.receiveShadow = true
   pivot.add(panel)
@@ -639,35 +731,61 @@ export interface HouseResult {
   bathroomDoor: THREE.Group
 }
 
+// ---------------------------------------------------------------------------
+// Room builder dispatch table
+// ---------------------------------------------------------------------------
+
+const ROOM_BUILDERS: Readonly<
+  Record<LayoutRoomId, (g: THREE.Group, xMin: number, xMax: number, floor: 1 | 2 | 3) => void>
+> = {
+  entrance: buildEntranceRoom,
+  living_room: buildLivingRoomFurniture,
+  kitchen: buildKitchenFurniture,
+  bedroom: buildBedroomFurniture,
+  bathroom: buildBathroomFurniture,
+  study: buildStudyFurniture,
+  hobby_room: buildHobbyRoomFurniture,
+  storage: buildStorageFurniture,
+}
+
+// ---------------------------------------------------------------------------
+// Main house builder
+// ---------------------------------------------------------------------------
+
 /**
  * Builds the complete house geometry as a THREE.Group.
  * The house origin is at (0,0,0) — bottom-left-front corner.
  *
- * Layout (LCP-inspired, left→right):
- *   Floor 1: Entry Hall (x 1–4) | Living Room (x 4–16) | Kitchen (x 16–27) | Staircase (x 27–32)
- *   Floor 2: Bedroom (x 1–14) | Bathroom (x 14–20) | Study (x 20–27) | Staircase
- *   Floor 3: Music Room (x 1–16) | Library (x 16–27) | Staircase
+ * Rooms are placed according to the provided HouseLayout.
  */
-export function buildHouse(): HouseResult {
+export function buildHouse(layout: HouseLayout): HouseResult {
   const house = new THREE.Group()
 
+  // Structural shells for all three floors
   for (const floor of [1, 2, 3] as const) {
     buildFloorShell(house, floor)
-    buildInteriorWalls(house, floor)
   }
 
-  buildEntranceHall(house)
-  buildLivingRoom(house)
-  buildKitchen(house)
-  buildBedroom(house)
-  buildBathroom(house)
-  buildStudy(house)
-  buildMusicRoom(house)
-  buildLibrary(house)
+  // Interior walls from layout
+  for (const floor of [1, 2, 3] as const) {
+    const floorWalls = layout.walls
+      .filter((w) => w.floor === floor)
+      .map((w) => w.x)
+    buildInteriorWalls(house, floor, floorWalls)
+  }
+
+  // Build furniture for each room slot
+  for (const slot of layout.slots) {
+    const builder = ROOM_BUILDERS[slot.roomId]
+    builder(house, slot.xMin, slot.xMax, slot.floor)
+  }
+
+  // Staircase (always fixed)
   buildStaircase(house)
 
-  // Bathroom door is a separate group so we can animate it
-  const bathroomDoor = buildBathroomDoor()
+  // Bathroom door — positioned from layout
+  const bathroomSlot = layout.slotMap.bathroom
+  const bathroomDoor = buildBathroomDoorForSlot(bathroomSlot)
   house.add(bathroomDoor)
 
   return { group: house, bathroomDoor }

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -11,6 +11,7 @@ export * from './character'
 export {
   ROOMS,
   ROOM_MAP,
+  buildRooms,
   getRoom,
   getRoomFloor,
   getRoomActivities,

--- a/src/game/renderer.ts
+++ b/src/game/renderer.ts
@@ -6,6 +6,8 @@ import { SfxEngine } from './sfx/engine'
 import type { CharacterState as SchemaCharacterState } from '@/lib/characterSchema'
 import type { ClothingItem } from '@/lib/characterSchema'
 import type { RoomId, ActivityType } from './rooms'
+import { buildRooms } from './rooms'
+import { generateLayout } from '@/lib/layout'
 
 // ---------------------------------------------------------------------------
 // Camera / pan / zoom helpers
@@ -187,9 +189,15 @@ export function initGame(
   scene.add(hemiLight)
 
   // ------------------------------------------------------------------
+  // Layout — deterministic from character name
+  // ------------------------------------------------------------------
+  const layout = generateLayout(characterName)
+  const { roomMap } = buildRooms(layout)
+
+  // ------------------------------------------------------------------
   // House geometry
   // ------------------------------------------------------------------
-  const { group: house, bathroomDoor } = buildHouse()
+  const { group: house, bathroomDoor } = buildHouse(layout)
   scene.add(house)
 
   // ------------------------------------------------------------------
@@ -212,7 +220,7 @@ export function initGame(
   // ------------------------------------------------------------------
   const sfxEngine = new SfxEngine()
 
-  const character = new Character(characterName, scene, gameCharacterState, sfxEngine)
+  const character = new Character(characterName, scene, gameCharacterState, sfxEngine, roomMap)
 
   // ------------------------------------------------------------------
   // Animation loop

--- a/src/game/rooms.ts
+++ b/src/game/rooms.ts
@@ -8,15 +8,12 @@
 //   Floors: 3, each FLOOR_HEIGHT voxels tall
 //   Floor Y origins: floor1=0, floor2=FLOOR_HEIGHT, floor3=FLOOR_HEIGHT*2
 //
-// Layout (LCP-inspired):
-//   Floor 1: Entry(x 1–4) | Living(x 4–16) | Kitchen(x 16–27) | Stair(x 27–32)
-//   Floor 2: Bedroom(x 1–14) | Bathroom(x 14–20) | Study(x 20–27) | Stair
-//   Floor 3: Music Room(x 1–16) | Library(x 16–27) | Stair
-//
 // Staircase connects all floors on the right side (x ≈ 27–32).
+// Room positions vary per character — see src/lib/layout.ts.
 
 import * as THREE from 'three'
 import { FLOOR_HEIGHT } from './house'
+import type { HouseLayout, LayoutRoomId } from '@/lib/layout'
 
 // ---------------------------------------------------------------------------
 // Activity types
@@ -73,15 +70,26 @@ export interface Room {
 
 /** Returns the Y world coordinate of the floor surface (top of slab) for a floor. */
 function floorCenterY(floor: 1 | 2 | 3): number {
-  // Floor slab center is at (floor-1)*FLOOR_HEIGHT + 0.5, so the top surface
-  // (where characters stand) is at (floor-1)*FLOOR_HEIGHT + 1.
-  // The character mesh origin is at feet (y=0 in local space), so placing
-  // the group at this Y means the feet touch the floor exactly.
   return (floor - 1) * FLOOR_HEIGHT + 1
 }
 
 // ---------------------------------------------------------------------------
-// Room definitions
+// Static activity map — activities are intrinsic to room type, not position
+// ---------------------------------------------------------------------------
+
+export const ACTIVITY_MAP: Readonly<Record<LayoutRoomId, readonly ActivityType[]>> = {
+  entrance: ['idle'],
+  living_room: ['relax', 'watch_tv', 'read', 'idle'],
+  kitchen: ['cook', 'eat', 'idle'],
+  bedroom: ['sleep', 'dress', 'idle'],
+  study: ['work', 'type', 'read', 'idle'],
+  bathroom: ['bathe', 'groom', 'use_bathroom', 'idle'],
+  hobby_room: ['paint', 'play_instrument', 'tinker', 'read', 'idle'],
+  storage: ['rummage', 'idle'],
+}
+
+// ---------------------------------------------------------------------------
+// Default room definitions (original fixed layout)
 // ---------------------------------------------------------------------------
 
 export const ROOMS: readonly Room[] = [
@@ -143,7 +151,7 @@ export const ROOMS: readonly Room[] = [
   },
   {
     id: 'staircase',
-    floor: 1, // spans all floors; floor 1 is just the base designation
+    floor: 1,
     center: new THREE.Vector3(29.5, floorCenterY(1), 4),
     activities: ['idle'],
     adjacentRooms: [
@@ -159,14 +167,77 @@ export const ROOMS: readonly Room[] = [
   },
 ]
 
-// ---------------------------------------------------------------------------
-// Lookup helpers
-// ---------------------------------------------------------------------------
-
 /** Map from RoomId to Room for O(1) lookup */
 export const ROOM_MAP: Readonly<Record<RoomId, Room>> = Object.fromEntries(
   ROOMS.map((r) => [r.id, r]),
 ) as Readonly<Record<RoomId, Room>>
+
+// ---------------------------------------------------------------------------
+// Build rooms from a layout
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds Room definitions from a HouseLayout. The rooms have layout-specific
+ * centers and adjacency, with the same activity lists as the default layout.
+ */
+export function buildRooms(layout: HouseLayout): {
+  rooms: Room[]
+  roomMap: Record<RoomId, Room>
+} {
+  // Group slots by floor and sort by xMin for adjacency
+  const floorSlots: Record<number, typeof layout.slots> = { 1: [], 2: [], 3: [] }
+  for (const slot of layout.slots) {
+    floorSlots[slot.floor].push(slot)
+  }
+  for (const floor of [1, 2, 3]) {
+    floorSlots[floor].sort((a, b) => a.xMin - b.xMin)
+  }
+
+  const rooms: Room[] = []
+
+  for (const floor of [1, 2, 3] as const) {
+    const slots = floorSlots[floor]
+    for (let i = 0; i < slots.length; i++) {
+      const slot = slots[i]
+      const roomId = slot.roomId as RoomId
+      const neighbors: RoomId[] = []
+
+      // Left neighbor
+      if (i > 0) neighbors.push(slots[i - 1].roomId as RoomId)
+      // Right neighbor
+      if (i < slots.length - 1) neighbors.push(slots[i + 1].roomId as RoomId)
+      // Always connected to staircase
+      neighbors.push('staircase')
+
+      rooms.push({
+        id: roomId,
+        floor,
+        center: new THREE.Vector3(slot.centerX, floorCenterY(floor), 4),
+        activities: [...ACTIVITY_MAP[slot.roomId]],
+        adjacentRooms: neighbors,
+      })
+    }
+  }
+
+  // Add staircase (always fixed position)
+  rooms.push({
+    id: 'staircase',
+    floor: 1,
+    center: new THREE.Vector3(29.5, floorCenterY(1), 4),
+    activities: ['idle'],
+    adjacentRooms: layout.slots.map((s) => s.roomId as RoomId),
+  })
+
+  const roomMap = Object.fromEntries(
+    rooms.map((r) => [r.id, r]),
+  ) as Record<RoomId, Room>
+
+  return { rooms, roomMap }
+}
+
+// ---------------------------------------------------------------------------
+// Lookup helpers
+// ---------------------------------------------------------------------------
 
 /** Returns the Room definition for a given RoomId */
 export function getRoom(id: RoomId): Room {

--- a/src/lib/kv.ts
+++ b/src/lib/kv.ts
@@ -1,6 +1,8 @@
 import { kv } from '@vercel/kv'
 import { CharacterState, CharacterStateSchema } from './characterSchema'
 import { VisitorLog, VisitorLogSchema, VisitorMessage } from './visitorSchema'
+import { generateLayout } from './layout'
+import { buildLayoutRoomData } from './roomDataBuilder'
 
 const KEY_PREFIX = 'character:'
 
@@ -60,6 +62,11 @@ export async function appendVisitorMessage(name: string, text: string): Promise<
 // ---------------------------------------------------------------------------
 
 export function createDefaultCharacter(name: string): CharacterState {
+  // Use the character's layout to place them at their living room center
+  const layout = generateLayout(name)
+  const roomData = buildLayoutRoomData(layout)
+  const livingRoomCenter = roomData.centers.living_room
+
   return {
     name,
     createdAt: new Date().toISOString(),
@@ -69,6 +76,6 @@ export function createDefaultCharacter(name: string): CharacterState {
     currentActivity: 'idle',
     needs: { hunger: 0.2, sleep: 0.1, hygiene: 0.1, entertainment: 0.2 },
     clock: { hour: 9, day: 0 },
-    position: { x: 4, y: 1, z: 4 },
+    position: { x: livingRoomCenter.x, y: livingRoomCenter.y, z: livingRoomCenter.z },
   }
 }

--- a/src/lib/layout.ts
+++ b/src/lib/layout.ts
@@ -1,0 +1,207 @@
+// ---------------------------------------------------------------------------
+// House layout generation — deterministic, seeded by character name
+// ---------------------------------------------------------------------------
+//
+// Generates a randomized room layout for a character's casa. The layout is
+// fully deterministic: the same name always produces the same layout. All
+// 8 rooms are shuffled freely across 3 floors (3+3+2 slots), with wall
+// positions computed proportionally based on room preferred widths.
+//
+// Server-safe — no Three.js dependency.
+
+import { seededRngFromKey } from '@/game/character/seeder'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type LayoutRoomId =
+  | 'living_room'
+  | 'kitchen'
+  | 'entrance'
+  | 'bedroom'
+  | 'study'
+  | 'bathroom'
+  | 'hobby_room'
+  | 'storage'
+
+export interface RoomSlot {
+  roomId: LayoutRoomId
+  floor: 1 | 2 | 3
+  /** Left edge x-coordinate (inclusive) */
+  xMin: number
+  /** Right edge x-coordinate (exclusive) */
+  xMax: number
+  /** Center x-coordinate */
+  centerX: number
+}
+
+export interface WallPosition {
+  floor: 1 | 2 | 3
+  /** x-coordinate of the wall center */
+  x: number
+}
+
+export interface HouseLayout {
+  slots: RoomSlot[]
+  walls: WallPosition[]
+  /** O(1) lookup by roomId */
+  slotMap: Readonly<Record<LayoutRoomId, RoomSlot>>
+}
+
+// ---------------------------------------------------------------------------
+// Room size preferences
+// ---------------------------------------------------------------------------
+
+interface RoomSizePrefs {
+  min: number
+  preferred: number
+}
+
+const ROOM_SIZES: Readonly<Record<LayoutRoomId, RoomSizePrefs>> = {
+  entrance: { min: 3, preferred: 4 },
+  living_room: { min: 6, preferred: 12 },
+  kitchen: { min: 6, preferred: 11 },
+  bedroom: { min: 6, preferred: 13 },
+  bathroom: { min: 5, preferred: 6 },
+  study: { min: 5, preferred: 7 },
+  hobby_room: { min: 6, preferred: 15 },
+  storage: { min: 5, preferred: 11 },
+}
+
+/** All room IDs in canonical order (for shuffling) */
+const ALL_ROOMS: readonly LayoutRoomId[] = [
+  'entrance',
+  'living_room',
+  'kitchen',
+  'bedroom',
+  'bathroom',
+  'study',
+  'hobby_room',
+  'storage',
+]
+
+/** Total room space per floor (x=1 to x=27, excluding exterior walls and staircase) */
+const FLOOR_ROOM_WIDTH = 26
+
+// ---------------------------------------------------------------------------
+// Layout generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generates a deterministic house layout from a character name.
+ * The same name always produces the same layout.
+ */
+export function generateLayout(characterName: string): HouseLayout {
+  const rng = seededRngFromKey(`layout:${characterName.toLowerCase()}`)
+
+  // Fisher-Yates shuffle all 8 rooms
+  const rooms = [...ALL_ROOMS]
+  for (let i = rooms.length - 1; i > 0; i--) {
+    const j = Math.floor(rng.next() * (i + 1))
+    ;[rooms[i], rooms[j]] = [rooms[j], rooms[i]]
+  }
+
+  // Assign to floors: first 3 → floor 1, next 3 → floor 2, last 2 → floor 3
+  const floorAssignments: LayoutRoomId[][] = [
+    rooms.slice(0, 3),
+    rooms.slice(3, 6),
+    rooms.slice(6, 8),
+  ]
+
+  const slots: RoomSlot[] = []
+  const walls: WallPosition[] = []
+
+  for (let f = 0; f < 3; f++) {
+    const floor = (f + 1) as 1 | 2 | 3
+    const floorRooms = floorAssignments[f]
+
+    // Calculate proportional widths
+    const totalPreferred = floorRooms.reduce(
+      (sum, r) => sum + ROOM_SIZES[r].preferred,
+      0,
+    )
+    const scale = FLOOR_ROOM_WIDTH / totalPreferred
+
+    let currentX = 1 // room space starts at x=1 (after left exterior wall)
+
+    for (let i = 0; i < floorRooms.length; i++) {
+      const roomId = floorRooms[i]
+      let width: number
+
+      if (i === floorRooms.length - 1) {
+        // Last room gets remainder to ensure exact fit
+        width = 27 - currentX
+      } else {
+        // Proportional width, respecting minimum
+        width = Math.max(
+          ROOM_SIZES[roomId].min,
+          Math.round(ROOM_SIZES[roomId].preferred * scale),
+        )
+        // Ensure remaining rooms can still fit their minimums
+        const remainingRooms = floorRooms.slice(i + 1)
+        const remainingMinWidth = remainingRooms.reduce(
+          (sum, r) => sum + ROOM_SIZES[r].min,
+          0,
+        )
+        const maxWidth = 27 - currentX - remainingMinWidth
+        width = Math.min(width, maxWidth)
+      }
+
+      const xMin = currentX
+      const xMax = currentX + width
+
+      slots.push({
+        roomId,
+        floor,
+        xMin,
+        xMax,
+        centerX: (xMin + xMax) / 2,
+      })
+
+      // Add interior wall between rooms (not after the last room on a floor)
+      if (i < floorRooms.length - 1) {
+        walls.push({ floor, x: xMax })
+      }
+
+      currentX = xMax
+    }
+  }
+
+  const slotMap = Object.fromEntries(
+    slots.map((s) => [s.roomId, s]),
+  ) as Record<LayoutRoomId, RoomSlot>
+
+  return { slots, walls, slotMap }
+}
+
+/**
+ * Returns the default layout that matches the original hardcoded room positions.
+ * Useful for backward compatibility and tests.
+ */
+export function getDefaultLayout(): HouseLayout {
+  const slots: RoomSlot[] = [
+    { roomId: 'entrance', floor: 1, xMin: 1, xMax: 4, centerX: 2.5 },
+    { roomId: 'living_room', floor: 1, xMin: 4, xMax: 16, centerX: 10 },
+    { roomId: 'kitchen', floor: 1, xMin: 16, xMax: 27, centerX: 21.5 },
+    { roomId: 'bedroom', floor: 2, xMin: 1, xMax: 14, centerX: 7.5 },
+    { roomId: 'bathroom', floor: 2, xMin: 14, xMax: 20, centerX: 17 },
+    { roomId: 'study', floor: 2, xMin: 20, xMax: 27, centerX: 23.5 },
+    { roomId: 'hobby_room', floor: 3, xMin: 1, xMax: 16, centerX: 8.5 },
+    { roomId: 'storage', floor: 3, xMin: 16, xMax: 27, centerX: 21.5 },
+  ]
+
+  const walls: WallPosition[] = [
+    { floor: 1, x: 4 },
+    { floor: 1, x: 16 },
+    { floor: 2, x: 14 },
+    { floor: 2, x: 20 },
+    { floor: 3, x: 16 },
+  ]
+
+  const slotMap = Object.fromEntries(
+    slots.map((s) => [s.roomId, s]),
+  ) as Record<LayoutRoomId, RoomSlot>
+
+  return { slots, walls, slotMap }
+}

--- a/src/lib/persistenceVersion.ts
+++ b/src/lib/persistenceVersion.ts
@@ -7,4 +7,4 @@
  * bundle will have their save requests rejected (409) by the server,
  * preventing stale state from overwriting current data.
  */
-export const PERSISTENCE_VERSION = 1
+export const PERSISTENCE_VERSION = 2

--- a/src/lib/roomDataBuilder.ts
+++ b/src/lib/roomDataBuilder.ts
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------
+// Layout-aware room data builder — server-safe (no Three.js)
+// ---------------------------------------------------------------------------
+//
+// Builds room centers, activities, and adjacency from a HouseLayout.
+// Used by simulateOffline.ts and other server-side code that needs
+// layout-specific room data without importing Three.js.
+
+import type { HouseLayout, LayoutRoomId } from './layout'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const FLOOR_HEIGHT = 8
+
+function floorY(floor: number): number {
+  return (floor - 1) * FLOOR_HEIGHT + 1
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RoomPosition {
+  x: number
+  y: number
+  z: number
+}
+
+export interface LayoutRoomData {
+  centers: Readonly<Record<string, RoomPosition>>
+  activities: Readonly<Record<string, readonly string[]>>
+  adjacency: Readonly<Record<string, string[]>>
+}
+
+// ---------------------------------------------------------------------------
+// Static activity lists (intrinsic to room type, not position)
+// ---------------------------------------------------------------------------
+
+const ROOM_ACTIVITY_MAP: Readonly<Record<LayoutRoomId, readonly string[]>> = {
+  entrance: ['idle'],
+  living_room: ['relax', 'watch_tv', 'read', 'idle'],
+  kitchen: ['cook', 'eat', 'idle'],
+  bedroom: ['sleep', 'dress', 'idle'],
+  study: ['work', 'type', 'read', 'idle'],
+  bathroom: ['bathe', 'groom', 'use_bathroom', 'idle'],
+  hobby_room: ['paint', 'play_instrument', 'tinker', 'read', 'idle'],
+  storage: ['rummage', 'idle'],
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds layout-aware room data (centers, activities, adjacency) from a
+ * HouseLayout. The result is server-safe (plain objects, no Three.js).
+ */
+export function buildLayoutRoomData(layout: HouseLayout): LayoutRoomData {
+  // Build centers from slots
+  const centers: Record<string, RoomPosition> = {}
+  for (const slot of layout.slots) {
+    centers[slot.roomId] = {
+      x: slot.centerX,
+      y: floorY(slot.floor),
+      z: 4,
+    }
+  }
+  // Staircase center (fixed)
+  centers['staircase'] = { x: 29.5, y: floorY(1), z: 4 }
+
+  // Activities are intrinsic to room type
+  const activities: Record<string, readonly string[]> = {
+    ...ROOM_ACTIVITY_MAP,
+    staircase: ['idle'],
+  }
+
+  // Build adjacency: linear chain per floor + staircase hub
+  const adjacency: Record<string, string[]> = {}
+
+  // Group slots by floor
+  const floorSlots: Record<number, typeof layout.slots> = { 1: [], 2: [], 3: [] }
+  for (const slot of layout.slots) {
+    floorSlots[slot.floor].push(slot)
+  }
+
+  // Sort each floor's slots by xMin (left to right)
+  for (const floor of [1, 2, 3]) {
+    floorSlots[floor].sort((a, b) => a.xMin - b.xMin)
+  }
+
+  // Build adjacency for each room
+  for (const floor of [1, 2, 3]) {
+    const slots = floorSlots[floor]
+    for (let i = 0; i < slots.length; i++) {
+      const roomId = slots[i].roomId
+      const neighbors: string[] = []
+
+      // Left neighbor
+      if (i > 0) neighbors.push(slots[i - 1].roomId)
+      // Right neighbor
+      if (i < slots.length - 1) neighbors.push(slots[i + 1].roomId)
+      // Always connected to staircase
+      neighbors.push('staircase')
+
+      adjacency[roomId] = neighbors
+    }
+  }
+
+  // Staircase is adjacent to all rooms
+  adjacency['staircase'] = layout.slots.map((s) => s.roomId)
+
+  return { centers, activities, adjacency }
+}

--- a/src/lib/simulateOffline.ts
+++ b/src/lib/simulateOffline.ts
@@ -14,6 +14,9 @@ import type { CharacterState, Needs } from './characterSchema'
 import type { ActivityType } from '@/game/rooms'
 import { ROOM_CENTERS, ROOM_ACTIVITIES } from './roomData'
 import { seedFromName, seededRngFromKey } from '@/game/character/seeder'
+import { generateLayout } from './layout'
+import { buildLayoutRoomData } from './roomDataBuilder'
+import type { LayoutRoomData } from './roomDataBuilder'
 import type { PersonalityBias, HobbyType } from '@/game/character/seeder'
 import {
   advanceNeeds,
@@ -169,7 +172,9 @@ function selectActivity(
   hobbyType: HobbyType,
   currentRoom: string,
   characterName: string,
+  roomData?: LayoutRoomData,
 ): { room: string; activity: string; durationHours: number } {
+  const activities = roomData?.activities ?? ROOM_ACTIVITIES
   // 1. Critical needs override
   const criticals = getCriticalNeeds(needs)
   if (criticals.length > 0) {
@@ -191,8 +196,8 @@ function selectActivity(
 
   // 3. Filter to viable candidates (activity exists in room)
   const viable = slot.candidates.filter((c) => {
-    const activities = ROOM_ACTIVITIES[c.room]
-    return activities && activities.includes(c.activity)
+    const roomActivities = activities[c.room]
+    return roomActivities && roomActivities.includes(c.activity)
   })
 
   const rng = seededRngFromKey(
@@ -276,6 +281,10 @@ export function simulateOffline(
   const gameHoursElapsed = realSecondsToGameHours(elapsedRealSeconds)
   const hoursToSimulate = Math.min(gameHoursElapsed, MAX_SIMULATION_HOURS)
 
+  // Compute layout-aware room data for this character
+  const layout = generateLayout(state.name)
+  const roomData = buildLayoutRoomData(layout)
+
   const appearance = seedFromName(state.name)
   let clock = { ...state.clock }
   let needs: Needs = { ...state.needs }
@@ -302,6 +311,7 @@ export function simulateOffline(
       appearance.hobbyType,
       currentRoom,
       state.name,
+      roomData,
     )
     currentRoom = next.room
     currentActivity = next.activity as ActivityType
@@ -309,8 +319,9 @@ export function simulateOffline(
     remaining -= step
   }
 
-  // Resolve final position from room center
-  const center = ROOM_CENTERS[currentRoom] ?? ROOM_CENTERS.living_room
+  // Resolve final position from layout-aware room center
+  const centers = roomData.centers
+  const center = centers[currentRoom] ?? centers.living_room
   const position = { x: center.x, y: center.y, z: center.z }
 
   return {

--- a/tests/unit/layout.test.ts
+++ b/tests/unit/layout.test.ts
@@ -1,0 +1,327 @@
+// ---------------------------------------------------------------------------
+// Unit tests for layout generation and room data builder
+// ---------------------------------------------------------------------------
+//
+// These tests verify:
+//   1. Determinism: same name always produces same layout
+//   2. Variety: different names produce different layouts
+//   3. Validity: all floors sum to 26 voxels, no room below minimum width
+//   4. Traversability: adjacency graph is symmetric and fully connected
+//
+// Run:  npm run test:unit
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { generateLayout, getDefaultLayout } from '../../src/lib/layout'
+import type { HouseLayout, LayoutRoomId } from '../../src/lib/layout'
+import { buildLayoutRoomData } from '../../src/lib/roomDataBuilder'
+
+// ---------------------------------------------------------------------------
+// Room size constraints (must match layout.ts)
+// ---------------------------------------------------------------------------
+
+const ROOM_MIN_WIDTHS: Record<LayoutRoomId, number> = {
+  entrance: 3,
+  living_room: 6,
+  kitchen: 6,
+  bedroom: 6,
+  bathroom: 5,
+  study: 5,
+  hobby_room: 6,
+  storage: 5,
+}
+
+const ALL_ROOMS: LayoutRoomId[] = [
+  'entrance',
+  'living_room',
+  'kitchen',
+  'bedroom',
+  'bathroom',
+  'study',
+  'hobby_room',
+  'storage',
+]
+
+const FLOOR_ROOM_WIDTH = 26 // x=1 to x=27
+
+// ---------------------------------------------------------------------------
+// Determinism
+// ---------------------------------------------------------------------------
+
+describe('layout determinism', () => {
+  test('same name always produces same layout', () => {
+    const a = generateLayout('Alice')
+    const b = generateLayout('Alice')
+
+    assert.deepStrictEqual(a.slots, b.slots)
+    assert.deepStrictEqual(a.walls, b.walls)
+  })
+
+  test('case-insensitive (Alice === alice)', () => {
+    const a = generateLayout('Alice')
+    const b = generateLayout('alice')
+
+    assert.deepStrictEqual(a.slots, b.slots)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Variety
+// ---------------------------------------------------------------------------
+
+describe('layout variety', () => {
+  test('different names produce different layouts', () => {
+    const names = ['Alice', 'Bob', 'Charlie', 'Diana', 'Edward']
+    const layouts = names.map(generateLayout)
+
+    // At least some pairs should differ in room assignment
+    let differenceFound = false
+    for (let i = 0; i < layouts.length; i++) {
+      for (let j = i + 1; j < layouts.length; j++) {
+        const aRoomOrder = layouts[i].slots.map((s) => s.roomId).join(',')
+        const bRoomOrder = layouts[j].slots.map((s) => s.roomId).join(',')
+        if (aRoomOrder !== bRoomOrder) {
+          differenceFound = true
+          break
+        }
+      }
+      if (differenceFound) break
+    }
+    assert.ok(differenceFound, 'Expected at least two different layouts among 5 names')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Validity
+// ---------------------------------------------------------------------------
+
+describe('layout validity', () => {
+  const testNames = ['Alice', 'Bob', 'Charlie', 'TestUser', 'ZZZ', 'a1b2c3']
+
+  for (const name of testNames) {
+    test(`${name}: all 8 rooms present`, () => {
+      const layout = generateLayout(name)
+      const roomIds = layout.slots.map((s) => s.roomId).sort()
+      assert.deepStrictEqual(roomIds, [...ALL_ROOMS].sort())
+    })
+
+    test(`${name}: each floor sums to ${FLOOR_ROOM_WIDTH} voxels`, () => {
+      const layout = generateLayout(name)
+
+      for (const floor of [1, 2, 3] as const) {
+        const floorSlots = layout.slots.filter((s) => s.floor === floor)
+        const totalWidth = floorSlots.reduce((sum, s) => sum + (s.xMax - s.xMin), 0)
+        assert.strictEqual(
+          totalWidth,
+          FLOOR_ROOM_WIDTH,
+          `Floor ${floor} total width is ${totalWidth}, expected ${FLOOR_ROOM_WIDTH}`,
+        )
+      }
+    })
+
+    test(`${name}: no room below minimum width`, () => {
+      const layout = generateLayout(name)
+
+      for (const slot of layout.slots) {
+        const width = slot.xMax - slot.xMin
+        const minWidth = ROOM_MIN_WIDTHS[slot.roomId]
+        assert.ok(
+          width >= minWidth,
+          `${slot.roomId} on floor ${slot.floor} has width ${width}, minimum is ${minWidth}`,
+        )
+      }
+    })
+
+    test(`${name}: rooms don't overlap and cover x=1..27`, () => {
+      const layout = generateLayout(name)
+
+      for (const floor of [1, 2, 3] as const) {
+        const floorSlots = layout.slots
+          .filter((s) => s.floor === floor)
+          .sort((a, b) => a.xMin - b.xMin)
+
+        // First room starts at x=1
+        assert.strictEqual(floorSlots[0].xMin, 1, `Floor ${floor} first room should start at x=1`)
+        // Last room ends at x=27
+        assert.strictEqual(
+          floorSlots[floorSlots.length - 1].xMax,
+          27,
+          `Floor ${floor} last room should end at x=27`,
+        )
+
+        // No gaps between rooms
+        for (let i = 1; i < floorSlots.length; i++) {
+          assert.strictEqual(
+            floorSlots[i].xMin,
+            floorSlots[i - 1].xMax,
+            `Floor ${floor}: gap between ${floorSlots[i - 1].roomId} and ${floorSlots[i].roomId}`,
+          )
+        }
+      }
+    })
+
+    test(`${name}: 3 rooms on floor 1, 3 on floor 2, 2 on floor 3`, () => {
+      const layout = generateLayout(name)
+
+      const f1 = layout.slots.filter((s) => s.floor === 1)
+      const f2 = layout.slots.filter((s) => s.floor === 2)
+      const f3 = layout.slots.filter((s) => s.floor === 3)
+
+      assert.strictEqual(f1.length, 3, `Floor 1 should have 3 rooms, got ${f1.length}`)
+      assert.strictEqual(f2.length, 3, `Floor 2 should have 3 rooms, got ${f2.length}`)
+      assert.strictEqual(f3.length, 2, `Floor 3 should have 2 rooms, got ${f3.length}`)
+    })
+
+    test(`${name}: centerX is midpoint of xMin and xMax`, () => {
+      const layout = generateLayout(name)
+
+      for (const slot of layout.slots) {
+        const expected = (slot.xMin + slot.xMax) / 2
+        assert.strictEqual(
+          slot.centerX,
+          expected,
+          `${slot.roomId}: centerX ${slot.centerX} !== (${slot.xMin}+${slot.xMax})/2 = ${expected}`,
+        )
+      }
+    })
+
+    test(`${name}: slotMap has correct entries`, () => {
+      const layout = generateLayout(name)
+
+      for (const slot of layout.slots) {
+        assert.deepStrictEqual(layout.slotMap[slot.roomId], slot)
+      }
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Default layout backward compatibility
+// ---------------------------------------------------------------------------
+
+describe('default layout', () => {
+  test('matches original hardcoded positions', () => {
+    const layout = getDefaultLayout()
+
+    assert.strictEqual(layout.slotMap.entrance.xMin, 1)
+    assert.strictEqual(layout.slotMap.entrance.xMax, 4)
+    assert.strictEqual(layout.slotMap.living_room.xMin, 4)
+    assert.strictEqual(layout.slotMap.living_room.xMax, 16)
+    assert.strictEqual(layout.slotMap.kitchen.xMin, 16)
+    assert.strictEqual(layout.slotMap.kitchen.xMax, 27)
+    assert.strictEqual(layout.slotMap.bedroom.xMin, 1)
+    assert.strictEqual(layout.slotMap.bedroom.xMax, 14)
+    assert.strictEqual(layout.slotMap.bathroom.xMin, 14)
+    assert.strictEqual(layout.slotMap.bathroom.xMax, 20)
+    assert.strictEqual(layout.slotMap.study.xMin, 20)
+    assert.strictEqual(layout.slotMap.study.xMax, 27)
+    assert.strictEqual(layout.slotMap.hobby_room.xMin, 1)
+    assert.strictEqual(layout.slotMap.hobby_room.xMax, 16)
+    assert.strictEqual(layout.slotMap.storage.xMin, 16)
+    assert.strictEqual(layout.slotMap.storage.xMax, 27)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Room data builder
+// ---------------------------------------------------------------------------
+
+describe('buildLayoutRoomData', () => {
+  test('returns correct centers for default layout', () => {
+    const layout = getDefaultLayout()
+    const data = buildLayoutRoomData(layout)
+
+    assert.strictEqual(data.centers.entrance.x, 2.5)
+    assert.strictEqual(data.centers.living_room.x, 10)
+    assert.strictEqual(data.centers.kitchen.x, 21.5)
+  })
+
+  test('staircase center is always at x=29.5', () => {
+    const names = ['Alice', 'Bob', 'Charlie']
+    for (const name of names) {
+      const layout = generateLayout(name)
+      const data = buildLayoutRoomData(layout)
+      assert.strictEqual(data.centers.staircase.x, 29.5)
+    }
+  })
+
+  test('all rooms have activities', () => {
+    const layout = generateLayout('TestUser')
+    const data = buildLayoutRoomData(layout)
+
+    for (const roomId of ALL_ROOMS) {
+      const activities = data.activities[roomId]
+      assert.ok(activities, `Missing activities for ${roomId}`)
+      assert.ok(activities.length > 0, `Empty activities for ${roomId}`)
+      assert.ok(activities.includes('idle'), `${roomId} should have idle activity`)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Traversability (adjacency graph)
+// ---------------------------------------------------------------------------
+
+describe('adjacency traversability', () => {
+  const testNames = ['Alice', 'Bob', 'Charlie', 'TestUser']
+
+  for (const name of testNames) {
+    test(`${name}: adjacency is symmetric`, () => {
+      const layout = generateLayout(name)
+      const data = buildLayoutRoomData(layout)
+
+      for (const [roomId, neighbors] of Object.entries(data.adjacency)) {
+        for (const neighbor of neighbors) {
+          assert.ok(
+            data.adjacency[neighbor]?.includes(roomId),
+            `${neighbor} should be adjacent to ${roomId} (asymmetric adjacency)`,
+          )
+        }
+      }
+    })
+
+    test(`${name}: all rooms reachable from any room (fully connected)`, () => {
+      const layout = generateLayout(name)
+      const data = buildLayoutRoomData(layout)
+
+      const allRoomIds = [...ALL_ROOMS.map(String), 'staircase']
+
+      // BFS from entrance
+      const visited = new Set<string>()
+      const queue: string[] = ['entrance']
+      visited.add('entrance')
+
+      while (queue.length > 0) {
+        const current = queue.shift()!
+        const neighbors = data.adjacency[current] ?? []
+        for (const neighbor of neighbors) {
+          if (!visited.has(neighbor)) {
+            visited.add(neighbor)
+            queue.push(neighbor)
+          }
+        }
+      }
+
+      for (const roomId of allRoomIds) {
+        assert.ok(
+          visited.has(roomId),
+          `Room ${roomId} is not reachable from entrance`,
+        )
+      }
+    })
+
+    test(`${name}: staircase is connected to all rooms`, () => {
+      const layout = generateLayout(name)
+      const data = buildLayoutRoomData(layout)
+
+      const staircaseNeighbors = data.adjacency.staircase ?? []
+      for (const roomId of ALL_ROOMS) {
+        assert.ok(
+          staircaseNeighbors.includes(roomId),
+          `Staircase should be adjacent to ${roomId}`,
+        )
+      }
+    })
+  }
+})


### PR DESCRIPTION
Each character now gets a unique, deterministic house layout generated
from their name via seeded RNG. All 8 rooms are shuffled across 3
floors with proportional width distribution respecting minimums.

Key changes:
- New layout.ts: generates HouseLayout with Fisher-Yates shuffle
- New roomDataBuilder.ts: server-safe room centers/activities/adjacency
- house.ts: all room builders parameterized with (xMin, xMax, floor)
  using anchor-based furniture positioning
- pathfinder/schedule/character: thread roomMap through for layout-aware
  navigation and activity selection
- renderer.ts: wires layout into house building and character creation
- simulateOffline.ts: uses layout-aware room data for offline simulation
- kv.ts: default character position uses their layout's living room
- Bump PERSISTENCE_VERSION to 2

https://claude.ai/code/session_018iuopQNTGQEXtFPtV3WLib