### PR TITLE
Fix sender search dropdown cutoff on mobile

### DIFF
--- a/src/components/VisitorPanel.tsx
+++ b/src/components/VisitorPanel.tsx
@@ -497,7 +497,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
   senderDropdown: {
     position: 'absolute',
-    top: '100%',
+    bottom: '100%',
     left: '40px',
     right: '56px',
     backgroundColor: '#111',


### PR DESCRIPTION
The sender dropdown opened downward (top: 100%) but the parent panel
has overflow: hidden with a fixed 420px height. When the message list
is full the dropdown extends past the panel bounds and gets clipped.
Open the dropdown upward (bottom: 100%) so it grows into the message
list area which always has room.

https://claude.ai/code/session_01ARvxZ3fSwjMPBnHLXqRJkw