### PR TITLE
Add wardrobe system: visitors can ask for clothes and accessories by keyword

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mi-casa-es-su-casa",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mi-casa-es-su-casa",
-      "version": "0.4.48",
+      "version": "0.4.49",
       "dependencies": {
         "@vercel/kv": "^3.0.0",
         "next": "^15.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mi-casa-es-su-casa",
-  "version": "0.4.36",
+  "version": "0.4.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mi-casa-es-su-casa",
-      "version": "0.4.36",
+      "version": "0.4.48",
       "dependencies": {
         "@vercel/kv": "^3.0.0",
         "next": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mi-casa-es-su-casa",
-  "version": "0.4.48",
+  "version": "0.4.49",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mi-casa-es-su-casa",
-  "version": "0.4.47",
+  "version": "0.4.48",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/BootScreen.tsx
+++ b/src/components/BootScreen.tsx
@@ -27,7 +27,7 @@ const SUFFIXES: { label: string; display: string; slug: string }[] = [
 // ─── Boot lines ───────────────────────────────────────────────────────────────
 
 const BOOT_LINES: string[] = [
-  'MI CASA ES SU CASA v0.4.48',
+  'MI CASA ES SU CASA v0.4.49',
   '',
   '',
   'LOADING HOUSE SUBSYSTEM.......... OK',

--- a/src/components/BootScreen.tsx
+++ b/src/components/BootScreen.tsx
@@ -27,7 +27,7 @@ const SUFFIXES: { label: string; display: string; slug: string }[] = [
 // ─── Boot lines ───────────────────────────────────────────────────────────────
 
 const BOOT_LINES: string[] = [
-  'MI CASA ES SU CASA v0.4.47',
+  'MI CASA ES SU CASA v0.4.48',
   '',
   '',
   'LOADING HOUSE SUBSYSTEM.......... OK',

--- a/src/components/CharacterView.tsx
+++ b/src/components/CharacterView.tsx
@@ -92,8 +92,10 @@ export function CharacterView({ name }: CharacterViewProps) {
     (text: string) => {
       // Cowboy hat easter egg
       if (text.trim().toLowerCase() === 'giddy up') {
-        gameActionsRef.current?.injectThought(`💌 ${text}`)
-        gameActionsRef.current?.putOnClothes('COWBOY_HAT')
+        gameActionsRef.current?.changeClothes(
+          [{ kind: 'accessory', item: 'COWBOY_HAT' }],
+          [`💌 ${text}`],
+        )
         return
       }
 
@@ -102,7 +104,7 @@ export function CharacterView({ name }: CharacterViewProps) {
       const wardrobe = matchWardrobeRequest(text, triggerSeedRef.current++)
       if (wardrobe) {
         const phrases = pickWardrobePhrases(triggerSeedRef.current++)
-        gameActionsRef.current?.changeClothes(wardrobe.changes, phrases)
+        gameActionsRef.current?.changeClothes(wardrobe, phrases)
         return
       }
 

--- a/src/components/CharacterView.tsx
+++ b/src/components/CharacterView.tsx
@@ -12,6 +12,7 @@ import type { CharacterState } from '@/lib/characterSchema'
 import type { LayoutRoomId } from '@/lib/layout'
 import { DEFAULT_STAIRCASE_INDEX } from '@/lib/layout'
 import { matchChatTrigger, pickResponsePhrases } from '@/game/character/chatTriggers'
+import { matchWardrobeRequest, pickWardrobePhrases } from '@/game/character/wardrobe'
 import type { TamagotchiAction } from '@/game/character/tamagotchiReactions'
 
 interface CharacterViewProps {
@@ -93,6 +94,15 @@ export function CharacterView({ name }: CharacterViewProps) {
       if (text.trim().toLowerCase() === 'giddy up') {
         gameActionsRef.current?.injectThought(`💌 ${text}`)
         gameActionsRef.current?.putOnClothes('COWBOY_HAT')
+        return
+      }
+
+      // Wardrobe requests ("I want a green shirt", "put on a top hat") —
+      // character heads to the bedroom wardrobe to change
+      const wardrobe = matchWardrobeRequest(text, triggerSeedRef.current++)
+      if (wardrobe) {
+        const phrases = pickWardrobePhrases(triggerSeedRef.current++)
+        gameActionsRef.current?.changeClothes(wardrobe.changes, phrases)
         return
       }
 

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -4,12 +4,14 @@ import { initGame } from '@/game'
 import type { GameInstance } from '@/game/types'
 import type { CharacterState } from '@/lib/characterSchema'
 import type { LayoutRoomId } from '@/lib/layout'
+import type { WardrobeChange } from '@/game/character/wardrobe'
 import { ThoughtBubble } from './ThoughtBubble'
 
 export interface GameActions {
   injectThought: (text: string) => void
   ringDoorbell: () => void
   putOnClothes: (item: string) => void
+  changeClothes: (changes: WardrobeChange[], responsePhrases: string[]) => void
   goToRoom: (room: string, activity: string, durationHours: number, responsePhrases: string[]) => void
   wakeUp: (responsePhrases: string[]) => void
   getState: () => CharacterState | null
@@ -181,6 +183,9 @@ export function GameCanvas({
         injectThought: (text: string) => { gameRef.current?.injectThought(text) },
         ringDoorbell: () => { gameRef.current?.ringDoorbell() },
         putOnClothes: (item: string) => { gameRef.current?.putOnClothes(item) },
+        changeClothes: (changes: WardrobeChange[], responsePhrases: string[]) => {
+          gameRef.current?.changeClothes(changes, responsePhrases)
+        },
         goToRoom: (room: string, activity: string, durationHours: number, responsePhrases: string[]) => {
           gameRef.current?.goToRoom(room, activity, durationHours, responsePhrases)
         },

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -10,7 +10,6 @@ import { ThoughtBubble } from './ThoughtBubble'
 export interface GameActions {
   injectThought: (text: string) => void
   ringDoorbell: () => void
-  putOnClothes: (item: string) => void
   changeClothes: (changes: WardrobeChange[], responsePhrases: string[]) => void
   goToRoom: (room: string, activity: string, durationHours: number, responsePhrases: string[]) => void
   wakeUp: (responsePhrases: string[]) => void
@@ -182,7 +181,6 @@ export function GameCanvas({
       onGameReady({
         injectThought: (text: string) => { gameRef.current?.injectThought(text) },
         ringDoorbell: () => { gameRef.current?.ringDoorbell() },
-        putOnClothes: (item: string) => { gameRef.current?.putOnClothes(item) },
         changeClothes: (changes: WardrobeChange[], responsePhrases: string[]) => {
           gameRef.current?.changeClothes(changes, responsePhrases)
         },

--- a/src/game/character/accessories.ts
+++ b/src/game/character/accessories.ts
@@ -6,8 +6,12 @@
 // Accessories are attached as child meshes of the head mesh so they
 // move with the character automatically.
 //
-// To add a new item: extend ClothingItem in characterSchema.ts and add a
-// case here in attachClothing().
+// Head is 1×1×1 with its front face on the -Z side (face features sit at
+// local z ≈ -0.51). Head top is at local y = +0.5; the torso top is at
+// local y = -0.5, so neck items sit around y ≈ -0.6.
+//
+// To add a new item: extend ClothingItem in characterSchema.ts, assign it
+// a slot in wardrobe.ts (ACCESSORY_SLOT), and add a case here.
 
 import * as THREE from 'three'
 import type { ClothingItem } from '@/lib/characterSchema'
@@ -22,14 +26,102 @@ function makePart(
   d: number,
   color: number,
   y: number,
+  x = 0,
+  z = 0,
 ): THREE.Mesh {
   const geo = new THREE.BoxGeometry(w, h, d)
   const mat = new THREE.MeshLambertMaterial({ color })
   const mesh = new THREE.Mesh(geo, mat)
   mesh.castShadow = true
   mesh.receiveShadow = true
-  mesh.position.y = y
+  mesh.position.set(x, y, z)
   return mesh
+}
+
+// ---------------------------------------------------------------------------
+// Per-item geometry builders
+// ---------------------------------------------------------------------------
+
+function buildParts(item: ClothingItem, group: THREE.Group): void {
+  switch (item) {
+    case 'COWBOY_HAT':
+      // Brim: wide flat box just above head top; crown on top
+      group.add(makePart(1.6, 0.08, 1.4, 0x8b5e3c, 0.54))
+      group.add(makePart(0.72, 0.45, 0.72, 0x8b5e3c, 0.81))
+      break
+
+    case 'TOP_HAT':
+      group.add(makePart(1.4, 0.08, 1.3, 0x2a2a35, 0.54)) // brim
+      group.add(makePart(0.8, 0.95, 0.8, 0x2a2a35, 1.05)) // tall crown
+      group.add(makePart(0.84, 0.18, 0.84, 0xd0453e, 0.68)) // red band
+      break
+
+    case 'CAP':
+      group.add(makePart(1.08, 0.4, 1.08, 0xd0453e, 0.62)) // dome
+      group.add(makePart(0.9, 0.07, 0.5, 0xd0453e, 0.45, 0, -0.75)) // front brim
+      break
+
+    case 'BEANIE':
+      group.add(makePart(1.12, 0.22, 1.12, 0x3aa8a0, 0.44)) // fold-up band
+      group.add(makePart(1.0, 0.35, 1.0, 0x3aa8a0, 0.7)) // dome
+      group.add(makePart(0.28, 0.28, 0.28, 0xf0f0f0, 0.98)) // pompom
+      break
+
+    case 'CROWN':
+      group.add(makePart(1.12, 0.28, 1.12, 0xe8c84a, 0.62)) // gold band
+      group.add(makePart(0.16, 0.28, 0.1, 0xe8c84a, 0.9, -0.35, -0.51)) // spikes
+      group.add(makePart(0.16, 0.28, 0.1, 0xe8c84a, 0.9, 0, -0.51))
+      group.add(makePart(0.16, 0.28, 0.1, 0xe8c84a, 0.9, 0.35, -0.51))
+      break
+
+    case 'PARTY_HAT':
+      // Stacked boxes approximate a cone, topped with a pompom
+      group.add(makePart(0.75, 0.3, 0.75, 0xe07aa8, 0.65))
+      group.add(makePart(0.5, 0.3, 0.5, 0x3aa8a0, 0.95))
+      group.add(makePart(0.28, 0.3, 0.28, 0xe8c84a, 1.25))
+      group.add(makePart(0.15, 0.15, 0.15, 0xf0f0f0, 1.45))
+      break
+
+    case 'SUNGLASSES':
+      group.add(makePart(0.3, 0.24, 0.06, 0x1a1a2e, 0.12, -0.19, -0.52)) // lenses
+      group.add(makePart(0.3, 0.24, 0.06, 0x1a1a2e, 0.12, 0.19, -0.52))
+      group.add(makePart(0.12, 0.06, 0.06, 0x1a1a2e, 0.14, 0, -0.52)) // bridge
+      break
+
+    case 'GLASSES':
+      group.add(makePart(0.28, 0.22, 0.05, 0xc0d8e8, 0.1, -0.18, -0.53)) // lenses
+      group.add(makePart(0.28, 0.22, 0.05, 0xc0d8e8, 0.1, 0.18, -0.53))
+      group.add(makePart(0.1, 0.05, 0.05, 0x1a1a2e, 0.12, 0, -0.53)) // bridge
+      break
+
+    case 'BOW_TIE':
+      // Sits at the torso top, in front of the body's front face (z = -0.3)
+      group.add(makePart(0.1, 0.1, 0.08, 0xd0453e, -0.6, 0, -0.34)) // knot
+      group.add(makePart(0.16, 0.16, 0.07, 0xd0453e, -0.6, -0.16, -0.33)) // wings
+      group.add(makePart(0.16, 0.16, 0.07, 0xd0453e, -0.6, 0.16, -0.33))
+      break
+
+    case 'SCARF':
+      group.add(makePart(1.08, 0.24, 0.68, 0x3aa8a0, -0.6)) // wrap around neck
+      group.add(makePart(0.26, 0.55, 0.08, 0x3aa8a0, -0.95, 0.22, -0.34)) // tail
+      break
+
+    case 'NECKLACE':
+      group.add(makePart(0.8, 0.07, 0.66, 0xe8c84a, -0.58)) // chain
+      group.add(makePart(0.14, 0.14, 0.08, 0xe8c84a, -0.7, 0, -0.35)) // pendant
+      break
+
+    case 'HEADPHONES':
+      group.add(makePart(1.14, 0.1, 0.35, 0x2a2a35, 0.56)) // headband
+      group.add(makePart(0.18, 0.4, 0.4, 0x8455c9, 0.05, -0.6, 0)) // ear cups
+      group.add(makePart(0.18, 0.4, 0.4, 0x8455c9, 0.05, 0.6, 0))
+      break
+
+    case 'MUSTACHE':
+      // Between the eyes (y 0.1) and mouth (y -0.18) on the face
+      group.add(makePart(0.44, 0.12, 0.06, 0x4a3524, -0.06, 0, -0.52))
+      break
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -44,19 +136,11 @@ export function attachClothing(item: ClothingItem, head: THREE.Mesh): void {
   // Guard against duplicates
   if (head.children.some((c) => c.userData.clothingItem === item)) return
 
-  switch (item) {
-    case 'COWBOY_HAT': {
-      const group = new THREE.Group()
-      group.userData.clothingItem = item
-      // Head is 1×1×1; head top is at local y = +0.5
-      // Brim: wide flat box just above head top
-      group.add(makePart(1.6, 0.08, 1.4, 0x8b5e3c, 0.54))
-      // Crown: narrower tall box sitting on top of brim
-      group.add(makePart(0.72, 0.45, 0.72, 0x8b5e3c, 0.81))
-      head.add(group)
-      break
-    }
-  }
+  const group = new THREE.Group()
+  group.userData.clothingItem = item
+  buildParts(item, group)
+  if (group.children.length === 0) return
+  head.add(group)
 }
 
 /**

--- a/src/game/character/accessories.ts
+++ b/src/game/character/accessories.ts
@@ -15,6 +15,7 @@
 
 import * as THREE from 'three'
 import type { ClothingItem } from '@/lib/characterSchema'
+import { OUTFIT_COLOR_HEX } from './wardrobe'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -46,40 +47,40 @@ function buildParts(item: ClothingItem, group: THREE.Group): void {
   switch (item) {
     case 'COWBOY_HAT':
       // Brim: wide flat box just above head top; crown on top
-      group.add(makePart(1.6, 0.08, 1.4, 0x8b5e3c, 0.54))
-      group.add(makePart(0.72, 0.45, 0.72, 0x8b5e3c, 0.81))
+      group.add(makePart(1.6, 0.08, 1.4, OUTFIT_COLOR_HEX.brown, 0.54))
+      group.add(makePart(0.72, 0.45, 0.72, OUTFIT_COLOR_HEX.brown, 0.81))
       break
 
     case 'TOP_HAT':
-      group.add(makePart(1.4, 0.08, 1.3, 0x2a2a35, 0.54)) // brim
-      group.add(makePart(0.8, 0.95, 0.8, 0x2a2a35, 1.05)) // tall crown
-      group.add(makePart(0.84, 0.18, 0.84, 0xd0453e, 0.68)) // red band
+      group.add(makePart(1.4, 0.08, 1.3, OUTFIT_COLOR_HEX.black, 0.54)) // brim
+      group.add(makePart(0.8, 0.95, 0.8, OUTFIT_COLOR_HEX.black, 1.05)) // tall crown
+      group.add(makePart(0.84, 0.18, 0.84, OUTFIT_COLOR_HEX.red, 0.68)) // red band
       break
 
     case 'CAP':
-      group.add(makePart(1.08, 0.4, 1.08, 0xd0453e, 0.62)) // dome
-      group.add(makePart(0.9, 0.07, 0.5, 0xd0453e, 0.45, 0, -0.75)) // front brim
+      group.add(makePart(1.08, 0.4, 1.08, OUTFIT_COLOR_HEX.red, 0.62)) // dome
+      group.add(makePart(0.9, 0.07, 0.5, OUTFIT_COLOR_HEX.red, 0.45, 0, -0.75)) // front brim
       break
 
     case 'BEANIE':
-      group.add(makePart(1.12, 0.22, 1.12, 0x3aa8a0, 0.44)) // fold-up band
-      group.add(makePart(1.0, 0.35, 1.0, 0x3aa8a0, 0.7)) // dome
-      group.add(makePart(0.28, 0.28, 0.28, 0xf0f0f0, 0.98)) // pompom
+      group.add(makePart(1.12, 0.22, 1.12, OUTFIT_COLOR_HEX.teal, 0.44)) // fold-up band
+      group.add(makePart(1.0, 0.35, 1.0, OUTFIT_COLOR_HEX.teal, 0.7)) // dome
+      group.add(makePart(0.28, 0.28, 0.28, OUTFIT_COLOR_HEX.white, 0.98)) // pompom
       break
 
     case 'CROWN':
-      group.add(makePart(1.12, 0.28, 1.12, 0xe8c84a, 0.62)) // gold band
-      group.add(makePart(0.16, 0.28, 0.1, 0xe8c84a, 0.9, -0.35, -0.51)) // spikes
-      group.add(makePart(0.16, 0.28, 0.1, 0xe8c84a, 0.9, 0, -0.51))
-      group.add(makePart(0.16, 0.28, 0.1, 0xe8c84a, 0.9, 0.35, -0.51))
+      group.add(makePart(1.12, 0.28, 1.12, OUTFIT_COLOR_HEX.yellow, 0.62)) // gold band
+      group.add(makePart(0.16, 0.28, 0.1, OUTFIT_COLOR_HEX.yellow, 0.9, -0.35, -0.51)) // spikes
+      group.add(makePart(0.16, 0.28, 0.1, OUTFIT_COLOR_HEX.yellow, 0.9, 0, -0.51))
+      group.add(makePart(0.16, 0.28, 0.1, OUTFIT_COLOR_HEX.yellow, 0.9, 0.35, -0.51))
       break
 
     case 'PARTY_HAT':
       // Stacked boxes approximate a cone, topped with a pompom
-      group.add(makePart(0.75, 0.3, 0.75, 0xe07aa8, 0.65))
-      group.add(makePart(0.5, 0.3, 0.5, 0x3aa8a0, 0.95))
-      group.add(makePart(0.28, 0.3, 0.28, 0xe8c84a, 1.25))
-      group.add(makePart(0.15, 0.15, 0.15, 0xf0f0f0, 1.45))
+      group.add(makePart(0.75, 0.3, 0.75, OUTFIT_COLOR_HEX.pink, 0.65))
+      group.add(makePart(0.5, 0.3, 0.5, OUTFIT_COLOR_HEX.teal, 0.95))
+      group.add(makePart(0.28, 0.3, 0.28, OUTFIT_COLOR_HEX.yellow, 1.25))
+      group.add(makePart(0.15, 0.15, 0.15, OUTFIT_COLOR_HEX.white, 1.45))
       break
 
     case 'SUNGLASSES':
@@ -96,25 +97,25 @@ function buildParts(item: ClothingItem, group: THREE.Group): void {
 
     case 'BOW_TIE':
       // Sits at the torso top, in front of the body's front face (z = -0.3)
-      group.add(makePart(0.1, 0.1, 0.08, 0xd0453e, -0.6, 0, -0.34)) // knot
-      group.add(makePart(0.16, 0.16, 0.07, 0xd0453e, -0.6, -0.16, -0.33)) // wings
-      group.add(makePart(0.16, 0.16, 0.07, 0xd0453e, -0.6, 0.16, -0.33))
+      group.add(makePart(0.1, 0.1, 0.08, OUTFIT_COLOR_HEX.red, -0.6, 0, -0.34)) // knot
+      group.add(makePart(0.16, 0.16, 0.07, OUTFIT_COLOR_HEX.red, -0.6, -0.16, -0.33)) // wings
+      group.add(makePart(0.16, 0.16, 0.07, OUTFIT_COLOR_HEX.red, -0.6, 0.16, -0.33))
       break
 
     case 'SCARF':
-      group.add(makePart(1.08, 0.24, 0.68, 0x3aa8a0, -0.6)) // wrap around neck
-      group.add(makePart(0.26, 0.55, 0.08, 0x3aa8a0, -0.95, 0.22, -0.34)) // tail
+      group.add(makePart(1.08, 0.24, 0.68, OUTFIT_COLOR_HEX.teal, -0.6)) // wrap around neck
+      group.add(makePart(0.26, 0.55, 0.08, OUTFIT_COLOR_HEX.teal, -0.95, 0.22, -0.34)) // tail
       break
 
     case 'NECKLACE':
-      group.add(makePart(0.8, 0.07, 0.66, 0xe8c84a, -0.58)) // chain
-      group.add(makePart(0.14, 0.14, 0.08, 0xe8c84a, -0.7, 0, -0.35)) // pendant
+      group.add(makePart(0.8, 0.07, 0.66, OUTFIT_COLOR_HEX.yellow, -0.58)) // chain
+      group.add(makePart(0.14, 0.14, 0.08, OUTFIT_COLOR_HEX.yellow, -0.7, 0, -0.35)) // pendant
       break
 
     case 'HEADPHONES':
-      group.add(makePart(1.14, 0.1, 0.35, 0x2a2a35, 0.56)) // headband
-      group.add(makePart(0.18, 0.4, 0.4, 0x8455c9, 0.05, -0.6, 0)) // ear cups
-      group.add(makePart(0.18, 0.4, 0.4, 0x8455c9, 0.05, 0.6, 0))
+      group.add(makePart(1.14, 0.1, 0.35, OUTFIT_COLOR_HEX.black, 0.56)) // headband
+      group.add(makePart(0.18, 0.4, 0.4, OUTFIT_COLOR_HEX.purple, 0.05, -0.6, 0)) // ear cups
+      group.add(makePart(0.18, 0.4, 0.4, OUTFIT_COLOR_HEX.purple, 0.05, 0.6, 0))
       break
 
     case 'MUSTACHE':
@@ -139,7 +140,6 @@ export function attachClothing(item: ClothingItem, head: THREE.Mesh): void {
   const group = new THREE.Group()
   group.userData.clothingItem = item
   buildParts(item, group)
-  if (group.children.length === 0) return
   head.add(group)
 }
 

--- a/src/game/character/character.ts
+++ b/src/game/character/character.ts
@@ -20,10 +20,12 @@
 
 import * as THREE from 'three'
 import { seedFromName } from './seeder'
-import { buildCharacterMesh } from './mesh'
+import { buildCharacterMesh, applyOutfitColors } from './mesh'
 import type { CharacterMesh } from './mesh'
-import { attachClothing } from './accessories'
-import type { ClothingItem } from '@/lib/characterSchema'
+import { attachClothing, detachClothing } from './accessories'
+import { ACCESSORY_SLOT, OUTFIT_COLOR_HEX } from './wardrobe'
+import type { WardrobeChange } from './wardrobe'
+import type { ClothingItem, OutfitColor } from '@/lib/characterSchema'
 import { CharacterStateMachine } from './stateMachine'
 import type { CharacterStateData } from './stateMachine'
 import { advanceNeeds, applyActivityEffect, countRecoveredNeeds, DEFAULT_NEEDS } from './needs'
@@ -95,6 +97,8 @@ export interface CharacterState {
   clock: GameClock
   position: { x: number; y: number; z: number }
   accessories: ClothingItem[]
+  shirtColor?: OutfitColor
+  pantsColor?: OutfitColor
   plantHealth?: number
   pesos?: number
 }
@@ -141,8 +145,12 @@ export class Character {
   private _thoughtQueue: string[] = []
   /** Clothing items currently worn by this character */
   private _accessories: ClothingItem[] = []
-  /** Clothing item queued to be applied after the next 'dress' activity completes */
-  private _clothingQueue: ClothingItem | null = null
+  /** Custom shirt color (torso + arms); null = seeded appearance color */
+  private _shirtColor: OutfitColor | null = null
+  /** Custom pants color (legs); null = seeded appearance color */
+  private _pantsColor: OutfitColor | null = null
+  /** Wardrobe changes queued to apply after the next 'dress' activity completes */
+  private _wardrobeQueue: WardrobeChange[] = []
   /** SFX engine for procedural sound synthesis (null if audio unavailable) */
   private sfx: SfxEngine | null = null
   /** Tracks animation progress to detect foot-down moments */
@@ -188,12 +196,21 @@ export class Character {
     // Initialize accessories from saved state (before building mesh so hat appears immediately)
     if (initialState) {
       this._accessories = [...(initialState.accessories ?? [])]
+      this._shirtColor = initialState.shirtColor ?? null
+      this._pantsColor = initialState.pantsColor ?? null
       this._plantHealth = initialState.plantHealth ?? 1.0
       this._pesos = initialState.pesos ?? 0
     }
 
     // Build Three.js mesh (passes accessories so they render on first frame)
     this.mesh = buildCharacterMesh(appearance, this._accessories)
+    if (this._shirtColor !== null || this._pantsColor !== null) {
+      applyOutfitColors(
+        this.mesh.parts,
+        this._shirtColor !== null ? OUTFIT_COLOR_HEX[this._shirtColor] : null,
+        this._pantsColor !== null ? OUTFIT_COLOR_HEX[this._pantsColor] : null,
+      )
+    }
     scene.add(this.mesh.group)
 
     // Initialize state from saved state or defaults
@@ -364,10 +381,10 @@ export class Character {
   private _updatePerforming(deltaGameHours: number): void {
     const done = this.fsm.advanceActivity(deltaGameHours)
     if (done) {
-      // If a clothing item was queued and we just finished dressing, apply it now
-      if (this.currentActivity === 'dress' && this._clothingQueue !== null) {
-        this._applyClothing(this._clothingQueue)
-        this._clothingQueue = null
+      // If wardrobe changes were queued and we just finished dressing, apply them now
+      if (this.currentActivity === 'dress' && this._wardrobeQueue.length > 0) {
+        this._applyWardrobe(this._wardrobeQueue)
+        this._wardrobeQueue = []
       }
       this._selectAndStartNextActivity()
     }
@@ -703,6 +720,8 @@ export class Character {
         z: this.mesh.group.position.z,
       },
       accessories: [...this._accessories],
+      shirtColor: this._shirtColor ?? undefined,
+      pantsColor: this._pantsColor ?? undefined,
       plantHealth: this._plantHealth,
       pesos: this._pesos,
     }
@@ -810,8 +829,34 @@ export class Character {
    * No-op if the character is already wearing the item.
    */
   putOnClothes(item: ClothingItem): void {
-    if (this._accessories.includes(item)) return
-    this._clothingQueue = item
+    this.changeClothes([{ kind: 'accessory', item }], [])
+  }
+
+  /**
+   * Walks the character to the bedroom wardrobe to apply a set of clothing
+   * changes (accessories, shirt color, pants color). Changes are applied
+   * visually when the 'dress' activity completes and persist via getState.
+   * Changes the character is already wearing are skipped; if nothing would
+   * change, only the first response phrase is shown.
+   */
+  changeClothes(changes: WardrobeChange[], responsePhrases: string[]): void {
+    const effective = changes.filter((change) => {
+      if (change.kind === 'accessory') return !this._accessories.includes(change.item)
+      if (change.kind === 'shirt') return change.color !== this._shirtColor
+      return change.color !== this._pantsColor
+    })
+
+    if (effective.length === 0) {
+      if (responsePhrases.length > 0) {
+        this._injectedThought = responsePhrases[0]
+        this._thoughtQueue = []
+      }
+      return
+    }
+
+    this._wardrobeQueue = effective
+    this._injectedThought = responsePhrases[0] ?? null
+    this._thoughtQueue = responsePhrases.slice(1)
 
     const effectiveRoom = this._getEffectiveCurrentRoom()
     this.currentRoom = effectiveRoom
@@ -833,10 +878,27 @@ export class Character {
     }
   }
 
-  private _applyClothing(item: ClothingItem): void {
-    if (this._accessories.includes(item)) return
-    this._accessories.push(item)
-    attachClothing(item, this.mesh.parts.head)
+  private _applyWardrobe(changes: WardrobeChange[]): void {
+    for (const change of changes) {
+      if (change.kind === 'accessory') {
+        if (this._accessories.includes(change.item)) continue
+        // One item per slot: putting on a top hat takes off the cowboy hat
+        const slot = ACCESSORY_SLOT[change.item]
+        const existing = this._accessories.find((a) => ACCESSORY_SLOT[a] === slot)
+        if (existing) {
+          detachClothing(existing, this.mesh.parts.head)
+          this._accessories = this._accessories.filter((a) => a !== existing)
+        }
+        this._accessories.push(change.item)
+        attachClothing(change.item, this.mesh.parts.head)
+      } else if (change.kind === 'shirt') {
+        this._shirtColor = change.color
+        applyOutfitColors(this.mesh.parts, OUTFIT_COLOR_HEX[change.color], null)
+      } else {
+        this._pantsColor = change.color
+        applyOutfitColors(this.mesh.parts, null, OUTFIT_COLOR_HEX[change.color])
+      }
+    }
   }
 
   /**

--- a/src/game/character/character.ts
+++ b/src/game/character/character.ts
@@ -23,7 +23,7 @@ import { seedFromName } from './seeder'
 import { buildCharacterMesh, applyOutfitColors } from './mesh'
 import type { CharacterMesh } from './mesh'
 import { attachClothing, detachClothing } from './accessories'
-import { ACCESSORY_SLOT, OUTFIT_COLOR_HEX } from './wardrobe'
+import { ACCESSORY_SLOT, resolveSlotConflicts } from './wardrobe'
 import type { WardrobeChange } from './wardrobe'
 import type { ClothingItem, OutfitColor } from '@/lib/characterSchema'
 import { CharacterStateMachine } from './stateMachine'
@@ -195,7 +195,8 @@ export class Character {
 
     // Initialize accessories from saved state (before building mesh so hat appears immediately)
     if (initialState) {
-      this._accessories = [...(initialState.accessories ?? [])]
+      // Normalize so a bad save can't render two items in the same slot
+      this._accessories = resolveSlotConflicts(initialState.accessories ?? [])
       this._shirtColor = initialState.shirtColor ?? null
       this._pantsColor = initialState.pantsColor ?? null
       this._plantHealth = initialState.plantHealth ?? 1.0
@@ -204,13 +205,7 @@ export class Character {
 
     // Build Three.js mesh (passes accessories so they render on first frame)
     this.mesh = buildCharacterMesh(appearance, this._accessories)
-    if (this._shirtColor !== null || this._pantsColor !== null) {
-      applyOutfitColors(
-        this.mesh.parts,
-        this._shirtColor !== null ? OUTFIT_COLOR_HEX[this._shirtColor] : null,
-        this._pantsColor !== null ? OUTFIT_COLOR_HEX[this._pantsColor] : null,
-      )
-    }
+    applyOutfitColors(this.mesh.parts, this._shirtColor, this._pantsColor)
     scene.add(this.mesh.group)
 
     // Initialize state from saved state or defaults
@@ -824,15 +819,6 @@ export class Character {
   }
 
   /**
-   * Walks the character to the bedroom wardrobe and puts on the given item.
-   * The item is applied visually when the 'dress' activity completes.
-   * No-op if the character is already wearing the item.
-   */
-  putOnClothes(item: ClothingItem): void {
-    this.changeClothes([{ kind: 'accessory', item }], [])
-  }
-
-  /**
    * Walks the character to the bedroom wardrobe to apply a set of clothing
    * changes (accessories, shirt color, pants color). Changes are applied
    * visually when the 'dress' activity completes and persist via getState.
@@ -855,33 +841,12 @@ export class Character {
     }
 
     this._wardrobeQueue = effective
-    this._injectedThought = responsePhrases[0] ?? null
-    this._thoughtQueue = responsePhrases.slice(1)
-
-    const effectiveRoom = this._getEffectiveCurrentRoom()
-    this.currentRoom = effectiveRoom
-
-    if (effectiveRoom === 'bedroom') {
-      this._moveFromPosition = null
-      this._startPerforming('dress', 0.15)
-    } else {
-      this._capturePosition(effectiveRoom)
-      const path = findPath(
-        effectiveRoom,
-        'bedroom',
-        `${this.name}:dress:${this.clock.day}:${Math.floor(this.clock.hour)}`,
-        this.roomMap,
-      )
-      this._queued = { activity: 'dress', durationHours: 0.15 }
-      this.fsm.transitionToMoving(path)
-      this.animationState = createAnimationState('walk')
-    }
+    this.goToRoom('bedroom', 'dress', 0.15, responsePhrases)
   }
 
   private _applyWardrobe(changes: WardrobeChange[]): void {
     for (const change of changes) {
       if (change.kind === 'accessory') {
-        if (this._accessories.includes(change.item)) continue
         // One item per slot: putting on a top hat takes off the cowboy hat
         const slot = ACCESSORY_SLOT[change.item]
         const existing = this._accessories.find((a) => ACCESSORY_SLOT[a] === slot)
@@ -893,10 +858,10 @@ export class Character {
         attachClothing(change.item, this.mesh.parts.head)
       } else if (change.kind === 'shirt') {
         this._shirtColor = change.color
-        applyOutfitColors(this.mesh.parts, OUTFIT_COLOR_HEX[change.color], null)
+        applyOutfitColors(this.mesh.parts, change.color, null)
       } else {
         this._pantsColor = change.color
-        applyOutfitColors(this.mesh.parts, null, OUTFIT_COLOR_HEX[change.color])
+        applyOutfitColors(this.mesh.parts, null, change.color)
       }
     }
   }

--- a/src/game/character/chatTriggers.ts
+++ b/src/game/character/chatTriggers.ts
@@ -6,7 +6,7 @@
 // reacts by navigating to the relevant room, performing an activity, and
 // showing 1–3 fun response thought bubbles with short gaps between them.
 
-import { seededRngFromKey } from './seeder'
+import { pickUniquePhrases } from './phrases'
 import type { RoomId, ActivityType } from '../rooms'
 
 // ---------------------------------------------------------------------------
@@ -292,14 +292,5 @@ export function matchChatTrigger(text: string): ChatTriggerMatch | null {
  * The first phrase is shown on arrival; the rest are queued with short gaps.
  */
 export function pickResponsePhrases(trigger: ChatTrigger, seed: number): string[] {
-  const rng = seededRngFromKey(`chat-response:${trigger.room}:${seed}`)
-  const count = 1 + rng.nextInt(3) // 1, 2, or 3
-  const available = [...trigger.responsePhrases]
-  const phrases: string[] = []
-  for (let i = 0; i < count && available.length > 0; i++) {
-    const idx = rng.nextInt(available.length)
-    phrases.push(available[idx])
-    available.splice(idx, 1)
-  }
-  return phrases
+  return pickUniquePhrases(trigger.responsePhrases, `chat-response:${trigger.room}:${seed}`)
 }

--- a/src/game/character/index.ts
+++ b/src/game/character/index.ts
@@ -81,6 +81,15 @@ export type { ChatTrigger, ChatTriggerMatch } from './chatTriggers'
 // Accessories
 export { attachClothing, detachClothing } from './accessories'
 
+// Wardrobe (keyword-driven clothing changes)
+export {
+  matchWardrobeRequest,
+  pickWardrobePhrases,
+  ACCESSORY_SLOT,
+  OUTFIT_COLOR_HEX,
+} from './wardrobe'
+export type { WardrobeChange, WardrobeMatch, AccessorySlot } from './wardrobe'
+
 // Main character class
 export { Character, REAL_SECONDS_PER_GAME_MINUTE } from './character'
 export type { CharacterState } from './character'

--- a/src/game/character/index.ts
+++ b/src/game/character/index.ts
@@ -85,10 +85,11 @@ export { attachClothing, detachClothing } from './accessories'
 export {
   matchWardrobeRequest,
   pickWardrobePhrases,
+  resolveSlotConflicts,
   ACCESSORY_SLOT,
   OUTFIT_COLOR_HEX,
 } from './wardrobe'
-export type { WardrobeChange, WardrobeMatch, AccessorySlot } from './wardrobe'
+export type { WardrobeChange, AccessorySlot } from './wardrobe'
 
 // Main character class
 export { Character, REAL_SECONDS_PER_GAME_MINUTE } from './character'

--- a/src/game/character/mesh.ts
+++ b/src/game/character/mesh.ts
@@ -81,6 +81,36 @@ function withPivot(mesh: THREE.Mesh, offsetY: number): THREE.Group {
 // ---------------------------------------------------------------------------
 
 /**
+ * Recolors the character's outfit in place. Shirt covers torso + arms;
+ * pants cover the legs. Pass null to leave a part unchanged.
+ *
+ * Arm/leg entries in CharacterMeshParts are actually pivot groups wrapping
+ * the real mesh, so this resolves the inner mesh before tinting.
+ */
+export function applyOutfitColors(
+  parts: CharacterMeshParts,
+  shirtHex: number | null,
+  pantsHex: number | null,
+): void {
+  const recolor = (part: THREE.Object3D, hex: number): void => {
+    const mesh =
+      part instanceof THREE.Mesh ? part : (part.children[0] as THREE.Mesh | undefined)
+    if (!mesh) return
+    const mat = mesh.material as THREE.MeshLambertMaterial
+    mat.color.setHex(hex)
+  }
+  if (shirtHex !== null) {
+    recolor(parts.body, shirtHex)
+    recolor(parts.leftArm, shirtHex)
+    recolor(parts.rightArm, shirtHex)
+  }
+  if (pantsHex !== null) {
+    recolor(parts.leftLeg, pantsHex)
+    recolor(parts.rightLeg, pantsHex)
+  }
+}
+
+/**
  * Builds a complete character mesh group from a seeded appearance.
  *
  * The returned `group` has its origin at the character's feet.

--- a/src/game/character/mesh.ts
+++ b/src/game/character/mesh.ts
@@ -16,9 +16,10 @@
 
 import * as THREE from 'three'
 import type { CharacterAppearance } from './seeder'
-import type { ClothingItem } from '@/lib/characterSchema'
+import type { ClothingItem, OutfitColor } from '@/lib/characterSchema'
 import type { FaceParts } from './face'
 import { attachClothing } from './accessories'
+import { OUTFIT_COLOR_HEX } from './wardrobe'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -89,8 +90,8 @@ function withPivot(mesh: THREE.Mesh, offsetY: number): THREE.Group {
  */
 export function applyOutfitColors(
   parts: CharacterMeshParts,
-  shirtHex: number | null,
-  pantsHex: number | null,
+  shirt: OutfitColor | null,
+  pants: OutfitColor | null,
 ): void {
   const recolor = (part: THREE.Object3D, hex: number): void => {
     const mesh =
@@ -99,14 +100,16 @@ export function applyOutfitColors(
     const mat = mesh.material as THREE.MeshLambertMaterial
     mat.color.setHex(hex)
   }
-  if (shirtHex !== null) {
-    recolor(parts.body, shirtHex)
-    recolor(parts.leftArm, shirtHex)
-    recolor(parts.rightArm, shirtHex)
+  if (shirt !== null) {
+    const hex = OUTFIT_COLOR_HEX[shirt]
+    recolor(parts.body, hex)
+    recolor(parts.leftArm, hex)
+    recolor(parts.rightArm, hex)
   }
-  if (pantsHex !== null) {
-    recolor(parts.leftLeg, pantsHex)
-    recolor(parts.rightLeg, pantsHex)
+  if (pants !== null) {
+    const hex = OUTFIT_COLOR_HEX[pants]
+    recolor(parts.leftLeg, hex)
+    recolor(parts.rightLeg, hex)
   }
 }
 

--- a/src/game/character/phrases.ts
+++ b/src/game/character/phrases.ts
@@ -196,6 +196,24 @@ export function pickPhrase(category: PhraseCategory, seed: number): string {
 }
 
 /**
+ * Pick 1–3 unique phrases from a pool, seeded by key so picks are stable.
+ * Used for reaction phrases: the first is shown on arrival, the rest are
+ * queued with short gaps between them.
+ */
+export function pickUniquePhrases(pool: readonly string[], seedKey: string): string[] {
+  const rng = seededRngFromKey(seedKey)
+  const count = 1 + rng.nextInt(3) // 1, 2, or 3
+  const available = [...pool]
+  const phrases: string[] = []
+  for (let i = 0; i < count && available.length > 0; i++) {
+    const idx = rng.nextInt(available.length)
+    phrases.push(available[idx])
+    available.splice(idx, 1)
+  }
+  return phrases
+}
+
+/**
  * Map current character context to a phrase category.
  *
  * Priority:

--- a/src/game/character/wardrobe.ts
+++ b/src/game/character/wardrobe.ts
@@ -1,0 +1,319 @@
+// ---------------------------------------------------------------------------
+// Wardrobe — keyword-driven clothing changes from visitor messages
+// ---------------------------------------------------------------------------
+//
+// When a visitor asks the character to change clothes ("I want a green
+// shirt", "put on a top hat and sunglasses"), the character walks to the
+// bedroom wardrobe, performs the 'dress' activity, and the requested
+// changes are applied when dressing completes.
+//
+// Server-safe — no Three.js dependency. Geometry for each accessory lives
+// in accessories.ts; this module owns the vocabulary and parsing.
+
+import { seededRngFromKey } from './seeder'
+import type { ClothingItem, OutfitColor } from '@/lib/characterSchema'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WardrobeChange =
+  | { kind: 'shirt'; color: OutfitColor }
+  | { kind: 'pants'; color: OutfitColor }
+  | { kind: 'accessory'; item: ClothingItem }
+
+export interface WardrobeMatch {
+  changes: WardrobeChange[]
+  /** The first garment/accessory keyword that matched (for tests/debugging) */
+  matchedKeyword: string
+}
+
+// ---------------------------------------------------------------------------
+// Colors
+// ---------------------------------------------------------------------------
+
+/** Canonical outfit colors and the hex used to tint the character mesh */
+export const OUTFIT_COLOR_HEX: Readonly<Record<OutfitColor, number>> = {
+  red: 0xd0453e,
+  orange: 0xe08a3c,
+  yellow: 0xe8c84a,
+  green: 0x4a9b4f,
+  teal: 0x3aa8a0,
+  blue: 0x3f6fd1,
+  purple: 0x8455c9,
+  pink: 0xe07aa8,
+  brown: 0x8b5e3c,
+  white: 0xf0f0f0,
+  black: 0x2a2a35,
+  gray: 0x9a9aa5,
+}
+
+const ALL_COLORS = Object.keys(OUTFIT_COLOR_HEX) as OutfitColor[]
+
+/** Color words visitors might use, mapped to a canonical color */
+const COLOR_WORDS: Readonly<Record<string, OutfitColor>> = {
+  red: 'red', crimson: 'red', scarlet: 'red', maroon: 'red',
+  orange: 'orange',
+  yellow: 'yellow', gold: 'yellow', golden: 'yellow',
+  green: 'green', lime: 'green', emerald: 'green', olive: 'green', forest: 'green',
+  teal: 'teal', turquoise: 'teal', cyan: 'teal', aqua: 'teal',
+  blue: 'blue', navy: 'blue', azure: 'blue', indigo: 'blue',
+  purple: 'purple', violet: 'purple', lavender: 'purple',
+  pink: 'pink', magenta: 'pink', rose: 'pink',
+  brown: 'brown', tan: 'brown', khaki: 'brown',
+  white: 'white',
+  black: 'black',
+  gray: 'gray', grey: 'gray', silver: 'gray',
+}
+
+// ---------------------------------------------------------------------------
+// Accessory slots — one item per slot; a new item replaces the old one
+// ---------------------------------------------------------------------------
+
+export type AccessorySlot = 'hat' | 'eyes' | 'neck' | 'ears' | 'face'
+
+export const ACCESSORY_SLOT: Readonly<Record<ClothingItem, AccessorySlot>> = {
+  COWBOY_HAT: 'hat',
+  TOP_HAT: 'hat',
+  CAP: 'hat',
+  BEANIE: 'hat',
+  CROWN: 'hat',
+  PARTY_HAT: 'hat',
+  SUNGLASSES: 'eyes',
+  GLASSES: 'eyes',
+  BOW_TIE: 'neck',
+  SCARF: 'neck',
+  NECKLACE: 'neck',
+  HEADPHONES: 'ears',
+  MUSTACHE: 'face',
+}
+
+// ---------------------------------------------------------------------------
+// Keyword vocabulary
+// ---------------------------------------------------------------------------
+//
+// Phrases are matched longest-first over word tokens, so "cowboy hat" wins
+// over the bare "hat" fallback. A color word seen before a garment applies
+// to that garment ("green shirt and blue pants").
+
+type KeywordEntry =
+  | { type: 'accessory'; item: ClothingItem }
+  | { type: 'garment'; kind: 'shirt' | 'pants'; defaultColor?: OutfitColor }
+  | { type: 'outfit' }
+
+const KEYWORDS: Readonly<Record<string, KeywordEntry>> = {
+  // --- Accessories: hats ---
+  'cowboy hat': { type: 'accessory', item: 'COWBOY_HAT' },
+  sombrero: { type: 'accessory', item: 'COWBOY_HAT' },
+  stetson: { type: 'accessory', item: 'COWBOY_HAT' },
+  'top hat': { type: 'accessory', item: 'TOP_HAT' },
+  tophat: { type: 'accessory', item: 'TOP_HAT' },
+  'party hat': { type: 'accessory', item: 'PARTY_HAT' },
+  'baseball cap': { type: 'accessory', item: 'CAP' },
+  cap: { type: 'accessory', item: 'CAP' },
+  hat: { type: 'accessory', item: 'CAP' },
+  beanie: { type: 'accessory', item: 'BEANIE' },
+  crown: { type: 'accessory', item: 'CROWN' },
+  tiara: { type: 'accessory', item: 'CROWN' },
+  // --- Accessories: eyes ---
+  sunglasses: { type: 'accessory', item: 'SUNGLASSES' },
+  shades: { type: 'accessory', item: 'SUNGLASSES' },
+  glasses: { type: 'accessory', item: 'GLASSES' },
+  spectacles: { type: 'accessory', item: 'GLASSES' },
+  specs: { type: 'accessory', item: 'GLASSES' },
+  // --- Accessories: neck ---
+  'bow tie': { type: 'accessory', item: 'BOW_TIE' },
+  bowtie: { type: 'accessory', item: 'BOW_TIE' },
+  scarf: { type: 'accessory', item: 'SCARF' },
+  necklace: { type: 'accessory', item: 'NECKLACE' },
+  // --- Accessories: ears & face ---
+  headphones: { type: 'accessory', item: 'HEADPHONES' },
+  mustache: { type: 'accessory', item: 'MUSTACHE' },
+  moustache: { type: 'accessory', item: 'MUSTACHE' },
+  // --- Garments: shirt (recolors torso + arms) ---
+  shirt: { type: 'garment', kind: 'shirt' },
+  sweater: { type: 'garment', kind: 'shirt' },
+  hoodie: { type: 'garment', kind: 'shirt' },
+  jacket: { type: 'garment', kind: 'shirt' },
+  blouse: { type: 'garment', kind: 'shirt' },
+  jersey: { type: 'garment', kind: 'shirt' },
+  'tank top': { type: 'garment', kind: 'shirt' },
+  // --- Garments: pants (recolors legs) ---
+  pants: { type: 'garment', kind: 'pants' },
+  trousers: { type: 'garment', kind: 'pants' },
+  jeans: { type: 'garment', kind: 'pants', defaultColor: 'blue' },
+  shorts: { type: 'garment', kind: 'pants' },
+  leggings: { type: 'garment', kind: 'pants' },
+  slacks: { type: 'garment', kind: 'pants' },
+  skirt: { type: 'garment', kind: 'pants' },
+  // --- Whole-outfit change (new shirt + pants colors) ---
+  clothes: { type: 'outfit' },
+  outfit: { type: 'outfit' },
+  wardrobe: { type: 'outfit' },
+  makeover: { type: 'outfit' },
+  'dress up': { type: 'outfit' },
+  'get dressed': { type: 'outfit' },
+  'new look': { type: 'outfit' },
+}
+
+/** Longest keyword phrase, in words */
+const MAX_PHRASE_WORDS = 2
+
+// ---------------------------------------------------------------------------
+// Matching
+// ---------------------------------------------------------------------------
+
+/**
+ * Scan a visitor message for clothing-change requests.
+ *
+ * Recognizes accessories ("top hat", "sunglasses"), colored garments
+ * ("green shirt", "blue pants"), and whole-outfit changes ("change
+ * clothes", "new outfit"). A color word before a garment applies to it;
+ * a garment without a color gets a seeded-random color (except items with
+ * a natural default, e.g. jeans → blue). Returns null if the message
+ * contains no clothing keywords.
+ *
+ * `seed` keeps the random color picks deterministic per call site.
+ */
+export function matchWardrobeRequest(text: string, seed = 0): WardrobeMatch | null {
+  if (!text) return null
+
+  const words = (text.toLowerCase().match(/[a-z]+/g) ?? []) as string[]
+  if (words.length === 0) return null
+
+  const rng = seededRngFromKey(`wardrobe:${seed}:${words.join(' ')}`)
+  const randomColor = (): OutfitColor => ALL_COLORS[rng.nextInt(ALL_COLORS.length)]
+
+  const changes: WardrobeChange[] = []
+  let matchedKeyword: string | null = null
+  let pendingColor: OutfitColor | null = null
+  const consumed = new Set<number>()
+
+  /** True if a keyword phrase starts at word index j */
+  const keywordStartsAt = (j: number): boolean => {
+    for (let len = Math.min(MAX_PHRASE_WORDS, words.length - j); len >= 1; len--) {
+      if (KEYWORDS[words.slice(j, j + len).join(' ')]) return true
+    }
+    return false
+  }
+
+  /**
+   * Handles trailing colors ("make the shirt green"): scan up to 3 words
+   * after a garment for a color word, unless it belongs to a following
+   * garment ("shirt and blue pants" must not steal blue).
+   */
+  const takeTrailingColor = (start: number): OutfitColor | null => {
+    for (let j = start; j < Math.min(start + 3, words.length); j++) {
+      if (keywordStartsAt(j)) return null
+      const color = COLOR_WORDS[words[j]]
+      if (color) {
+        if (j + 1 < words.length && keywordStartsAt(j + 1)) return null
+        consumed.add(j)
+        return color
+      }
+    }
+    return null
+  }
+
+  let i = 0
+  while (i < words.length) {
+    if (consumed.has(i)) {
+      i++
+      continue
+    }
+    // Try longest phrase first so "cowboy hat" beats the bare "hat"
+    let entry: KeywordEntry | undefined
+    let phrase = ''
+    let len = Math.min(MAX_PHRASE_WORDS, words.length - i)
+    for (; len >= 1; len--) {
+      phrase = words.slice(i, i + len).join(' ')
+      entry = KEYWORDS[phrase]
+      if (entry) break
+    }
+
+    if (entry) {
+      matchedKeyword ??= phrase
+      switch (entry.type) {
+        case 'accessory':
+          changes.push({ kind: 'accessory', item: entry.item })
+          break
+        case 'garment': {
+          const color =
+            pendingColor ?? takeTrailingColor(i + len) ?? entry.defaultColor ?? randomColor()
+          changes.push({ kind: entry.kind, color })
+          break
+        }
+        case 'outfit': {
+          // "green clothes" / "make the outfit green" → all one color;
+          // otherwise fresh random colors for shirt and pants
+          const color = pendingColor ?? takeTrailingColor(i + len)
+          changes.push(
+            { kind: 'shirt', color: color ?? randomColor() },
+            { kind: 'pants', color: color ?? randomColor() },
+          )
+          break
+        }
+      }
+      pendingColor = null
+      i += len
+    } else {
+      const color = COLOR_WORDS[words[i]]
+      if (color) pendingColor = color
+      i++
+    }
+  }
+
+  if (changes.length === 0 || matchedKeyword === null) return null
+
+  // Collapse to one change per slot — the last mention wins, so
+  // "change clothes, and make the shirt green" ends up with a green shirt.
+  const seenSlots = new Set<string>()
+  const deduped: WardrobeChange[] = []
+  for (let j = changes.length - 1; j >= 0; j--) {
+    const change = changes[j]
+    const slot =
+      change.kind === 'accessory' ? `acc:${ACCESSORY_SLOT[change.item]}` : change.kind
+    if (seenSlots.has(slot)) continue
+    seenSlots.add(slot)
+    deduped.unshift(change)
+  }
+
+  return { changes: deduped, matchedKeyword }
+}
+
+// ---------------------------------------------------------------------------
+// Response phrases
+// ---------------------------------------------------------------------------
+
+const WARDROBE_PHRASES: readonly string[] = [
+  'Time for a wardrobe change!',
+  'Ooh, dress-up time!',
+  'How do I look?',
+  'Fresh new look, coming right up!',
+  'Fashion is my passion!',
+  'To the wardrobe!',
+  'A little makeover never hurt anyone.',
+  'Do these colors match? Who cares!',
+  'Strike a pose!',
+  "Lookin' sharp!",
+  'My stylist has spoken!',
+  'New clothes, new me.',
+]
+
+/**
+ * Pick 1–3 unique wardrobe response phrases. The first is shown on arrival
+ * at the wardrobe; the rest are queued with short gaps (same contract as
+ * pickResponsePhrases in chatTriggers.ts).
+ */
+export function pickWardrobePhrases(seed: number): string[] {
+  const rng = seededRngFromKey(`wardrobe-response:${seed}`)
+  const count = 1 + rng.nextInt(3) // 1, 2, or 3
+  const available = [...WARDROBE_PHRASES]
+  const phrases: string[] = []
+  for (let i = 0; i < count && available.length > 0; i++) {
+    const idx = rng.nextInt(available.length)
+    phrases.push(available[idx])
+    available.splice(idx, 1)
+  }
+  return phrases
+}

--- a/src/game/character/wardrobe.ts
+++ b/src/game/character/wardrobe.ts
@@ -11,6 +11,7 @@
 // in accessories.ts; this module owns the vocabulary and parsing.
 
 import { seededRngFromKey } from './seeder'
+import { pickUniquePhrases } from './phrases'
 import type { ClothingItem, OutfitColor } from '@/lib/characterSchema'
 
 // ---------------------------------------------------------------------------
@@ -21,12 +22,6 @@ export type WardrobeChange =
   | { kind: 'shirt'; color: OutfitColor }
   | { kind: 'pants'; color: OutfitColor }
   | { kind: 'accessory'; item: ClothingItem }
-
-export interface WardrobeMatch {
-  changes: WardrobeChange[]
-  /** The first garment/accessory keyword that matched (for tests/debugging) */
-  matchedKeyword: string
-}
 
 // ---------------------------------------------------------------------------
 // Colors
@@ -86,6 +81,17 @@ export const ACCESSORY_SLOT: Readonly<Record<ClothingItem, AccessorySlot>> = {
   NECKLACE: 'neck',
   HEADPHONES: 'ears',
   MUSTACHE: 'face',
+}
+
+/**
+ * Enforces the one-item-per-slot invariant on a worn-accessories list:
+ * for each slot the last-listed item wins. Used to normalize saved state
+ * on load so e.g. two hats from an old save can't both render.
+ */
+export function resolveSlotConflicts(items: readonly ClothingItem[]): ClothingItem[] {
+  const bySlot = new Map<AccessorySlot, ClothingItem>()
+  for (const item of items) bySlot.set(ACCESSORY_SLOT[item], item)
+  return [...bySlot.values()]
 }
 
 // ---------------------------------------------------------------------------
@@ -156,8 +162,10 @@ const KEYWORDS: Readonly<Record<string, KeywordEntry>> = {
   'new look': { type: 'outfit' },
 }
 
-/** Longest keyword phrase, in words */
-const MAX_PHRASE_WORDS = 2
+/** Longest keyword phrase, in words (derived so new phrases can't outgrow it) */
+const MAX_PHRASE_WORDS = Math.max(
+  ...Object.keys(KEYWORDS).map((k) => k.split(' ').length),
+)
 
 // ---------------------------------------------------------------------------
 // Matching
@@ -170,22 +178,23 @@ const MAX_PHRASE_WORDS = 2
  * ("green shirt", "blue pants"), and whole-outfit changes ("change
  * clothes", "new outfit"). A color word before a garment applies to it;
  * a garment without a color gets a seeded-random color (except items with
- * a natural default, e.g. jeans → blue). Returns null if the message
- * contains no clothing keywords.
+ * a natural default, e.g. jeans → blue). Returns the requested changes,
+ * at most one per slot (the last mention wins, so "change clothes, and
+ * make the shirt green" ends up with a green shirt), or null if the
+ * message contains no clothing keywords.
  *
  * `seed` keeps the random color picks deterministic per call site.
  */
-export function matchWardrobeRequest(text: string, seed = 0): WardrobeMatch | null {
+export function matchWardrobeRequest(text: string, seed = 0): WardrobeChange[] | null {
   if (!text) return null
 
-  const words = (text.toLowerCase().match(/[a-z]+/g) ?? []) as string[]
+  const words = text.toLowerCase().match(/[a-z]+/g) ?? []
   if (words.length === 0) return null
 
   const rng = seededRngFromKey(`wardrobe:${seed}:${words.join(' ')}`)
-  const randomColor = (): OutfitColor => ALL_COLORS[rng.nextInt(ALL_COLORS.length)]
+  const randomColor = (): OutfitColor => rng.pick(ALL_COLORS)
 
   const changes: WardrobeChange[] = []
-  let matchedKeyword: string | null = null
   let pendingColor: OutfitColor | null = null
   const consumed = new Set<number>()
 
@@ -232,7 +241,6 @@ export function matchWardrobeRequest(text: string, seed = 0): WardrobeMatch | nu
     }
 
     if (entry) {
-      matchedKeyword ??= phrase
       switch (entry.type) {
         case 'accessory':
           changes.push({ kind: 'accessory', item: entry.item })
@@ -263,22 +271,16 @@ export function matchWardrobeRequest(text: string, seed = 0): WardrobeMatch | nu
     }
   }
 
-  if (changes.length === 0 || matchedKeyword === null) return null
+  if (changes.length === 0) return null
 
-  // Collapse to one change per slot — the last mention wins, so
-  // "change clothes, and make the shirt green" ends up with a green shirt.
-  const seenSlots = new Set<string>()
-  const deduped: WardrobeChange[] = []
-  for (let j = changes.length - 1; j >= 0; j--) {
-    const change = changes[j]
+  // Collapse to one change per slot — forward Map.set gives last-wins
+  const bySlot = new Map<string, WardrobeChange>()
+  for (const change of changes) {
     const slot =
       change.kind === 'accessory' ? `acc:${ACCESSORY_SLOT[change.item]}` : change.kind
-    if (seenSlots.has(slot)) continue
-    seenSlots.add(slot)
-    deduped.unshift(change)
+    bySlot.set(slot, change)
   }
-
-  return { changes: deduped, matchedKeyword }
+  return [...bySlot.values()]
 }
 
 // ---------------------------------------------------------------------------
@@ -302,18 +304,8 @@ const WARDROBE_PHRASES: readonly string[] = [
 
 /**
  * Pick 1–3 unique wardrobe response phrases. The first is shown on arrival
- * at the wardrobe; the rest are queued with short gaps (same contract as
- * pickResponsePhrases in chatTriggers.ts).
+ * at the wardrobe; the rest are queued with short gaps between them.
  */
 export function pickWardrobePhrases(seed: number): string[] {
-  const rng = seededRngFromKey(`wardrobe-response:${seed}`)
-  const count = 1 + rng.nextInt(3) // 1, 2, or 3
-  const available = [...WARDROBE_PHRASES]
-  const phrases: string[] = []
-  for (let i = 0; i < count && available.length > 0; i++) {
-    const idx = rng.nextInt(available.length)
-    phrases.push(available[idx])
-    available.splice(idx, 1)
-  }
-  return phrases
+  return pickUniquePhrases(WARDROBE_PHRASES, `wardrobe-response:${seed}`)
 }

--- a/src/game/house.ts
+++ b/src/game/house.ts
@@ -394,6 +394,15 @@ function buildBedroomFurniture(
       { position: { x: xMin + 1, y: ft + 2.5, z: 6.8 }, color: PALETTE.DESK, size: { x: 1, y: 4, z: 0.3 } },
       { position: { x: xMin + 2, y: ft + 2.5, z: 6.8 }, color: PALETTE.DESK, size: { x: 1, y: 4, z: 0.3 } },
     ], items)
+  } else {
+    // Narrow bedroom: the back wall is fully taken by the bed, so place a
+    // compact free-standing armoire near the front corner. Visitors can
+    // always send the character here to change clothes.
+    addItem(group, 'wardrobe', [
+      { position: { x: xMin + 1, y: ft + 2, z: 2.0 }, color: PALETTE.WARDROBE, size: { x: 1.8, y: 4, z: 1.0 } },
+      { position: { x: xMin + 1, y: ft + 2, z: 1.4 }, color: PALETTE.DESK, size: { x: 1.4, y: 3.6, z: 0.2 } },
+      { position: { x: xMin + 1.45, y: ft + 2, z: 1.25 }, color: PALETTE.FRIDGE, size: { x: 0.15, y: 0.6, z: 0.15 } },
+    ], items)
   }
 
   if (w >= 10) {

--- a/src/game/renderer.ts
+++ b/src/game/renderer.ts
@@ -3,6 +3,7 @@ import { buildHouse, HOUSE_WIDTH, FLOOR_HEIGHT, FLOOR_COUNT, HOUSE_DEPTH, setLam
 import type { ClockHands, LampRecord, PlantRecord, ItemRecord } from './house'
 import type { GameInstance } from './types'
 import { Character } from './character'
+import type { WardrobeChange } from './character/wardrobe'
 import { SfxEngine } from './sfx/engine'
 import type { CharacterState as SchemaCharacterState } from '@/lib/characterSchema'
 import type { ClothingItem } from '@/lib/characterSchema'
@@ -133,6 +134,7 @@ export function initGame(
       injectThought() {},
       ringDoorbell() {},
       putOnClothes() {},
+      changeClothes() {},
       goToRoom() {},
       wakeUp() {},
       getCharacterState() { return null },
@@ -908,6 +910,9 @@ export function initGame(
     putOnClothes(item: string) {
       character.putOnClothes(item as ClothingItem)
     },
+    changeClothes(changes: WardrobeChange[], responsePhrases: string[]) {
+      character.changeClothes(changes, responsePhrases)
+    },
     goToRoom(room: string, activity: string, durationHours: number, responsePhrases: string[]) {
       character.goToRoom(
         room as RoomId,
@@ -938,6 +943,8 @@ export function initGame(
         clock: s.clock,
         position: s.position,
         accessories: s.accessories,
+        shirtColor: s.shirtColor,
+        pantsColor: s.pantsColor,
         plantHealth: s.plantHealth,
         pesos: s.pesos ?? 0,
       }

--- a/src/game/renderer.ts
+++ b/src/game/renderer.ts
@@ -6,7 +6,6 @@ import { Character } from './character'
 import type { WardrobeChange } from './character/wardrobe'
 import { SfxEngine } from './sfx/engine'
 import type { CharacterState as SchemaCharacterState } from '@/lib/characterSchema'
-import type { ClothingItem } from '@/lib/characterSchema'
 import type { RoomId, ActivityType } from './rooms'
 import { buildRooms } from './rooms'
 import { generateLayout, layoutFromOrder, roomOrderFromLayout, stairXPerFloorFromLayout, DEFAULT_STAIRCASE_INDEX } from '@/lib/layout'
@@ -133,7 +132,6 @@ export function initGame(
       applyZoomScale() {},
       injectThought() {},
       ringDoorbell() {},
-      putOnClothes() {},
       changeClothes() {},
       goToRoom() {},
       wakeUp() {},
@@ -307,7 +305,9 @@ export function initGame(
         needs: initialState.needs,
         clock: initialState.clock,
         position: initialState.position,
-        accessories: (initialState.accessories ?? []) as ClothingItem[],
+        accessories: initialState.accessories ?? [],
+        shirtColor: initialState.shirtColor,
+        pantsColor: initialState.pantsColor,
         plantHealth: initialState.plantHealth,
       }
     : undefined
@@ -906,9 +906,6 @@ export function initGame(
       sfxEngine.unlock() // idempotent — ensures AudioContext is ready on first click
       sfxEngine.playDoorbell()
       character.ringDoorbell()
-    },
-    putOnClothes(item: string) {
-      character.putOnClothes(item as ClothingItem)
     },
     changeClothes(changes: WardrobeChange[], responsePhrases: string[]) {
       character.changeClothes(changes, responsePhrases)

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -67,11 +67,6 @@ export interface GameInstance {
    */
   ringDoorbell(): void
   /**
-   * Walks the character to the wardrobe and puts on the given clothing item.
-   * The item persists in the character's saved state.
-   */
-  putOnClothes(item: string): void
-  /**
    * Walks the character to the bedroom wardrobe to apply clothing changes
    * (accessories, shirt/pants colors). Shows a response thought on arrival.
    * The changes persist in the character's saved state.

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -34,6 +34,7 @@ export interface Room {
 
 import type { CharacterState as SchemaCharacterState } from '@/lib/characterSchema'
 import type { LayoutRoomId } from '@/lib/layout'
+import type { WardrobeChange } from '@/game/character/wardrobe'
 
 export interface GameInstance {
   dispose(): void
@@ -70,6 +71,12 @@ export interface GameInstance {
    * The item persists in the character's saved state.
    */
   putOnClothes(item: string): void
+  /**
+   * Walks the character to the bedroom wardrobe to apply clothing changes
+   * (accessories, shirt/pants colors). Shows a response thought on arrival.
+   * The changes persist in the character's saved state.
+   */
+  changeClothes(changes: WardrobeChange[], responsePhrases: string[]): void
   /**
    * Interrupts the current activity and sends the character to a specific room
    * to perform the given activity, showing a response thought on arrival.

--- a/src/lib/characterSchema.ts
+++ b/src/lib/characterSchema.ts
@@ -1,7 +1,37 @@
 import { z } from 'zod'
 
-export const ClothingItemSchema = z.enum(['COWBOY_HAT'])
+export const ClothingItemSchema = z.enum([
+  'COWBOY_HAT',
+  'TOP_HAT',
+  'CAP',
+  'BEANIE',
+  'CROWN',
+  'PARTY_HAT',
+  'SUNGLASSES',
+  'GLASSES',
+  'BOW_TIE',
+  'SCARF',
+  'NECKLACE',
+  'HEADPHONES',
+  'MUSTACHE',
+])
 export type ClothingItem = z.infer<typeof ClothingItemSchema>
+
+export const OutfitColorSchema = z.enum([
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'teal',
+  'blue',
+  'purple',
+  'pink',
+  'brown',
+  'white',
+  'black',
+  'gray',
+])
+export type OutfitColor = z.infer<typeof OutfitColorSchema>
 
 export const NeedsSchema = z.object({
   hunger: z.number().min(0).max(1),
@@ -57,6 +87,8 @@ export const CharacterStateSchema = z.object({
     z: z.number(),
   }),
   accessories: z.array(ClothingItemSchema).optional(),
+  shirtColor: OutfitColorSchema.optional(),
+  pantsColor: OutfitColorSchema.optional(),
   lastActiveAt: z.string().datetime().optional(),
   plantHealth: z.number().min(0).max(1).optional(),
   pesos: z.number().min(0).optional().default(0),

--- a/src/lib/persistenceVersion.ts
+++ b/src/lib/persistenceVersion.ts
@@ -7,4 +7,4 @@
  * bundle will have their save requests rejected (409) by the server,
  * preventing stale state from overwriting current data.
  */
-export const PERSISTENCE_VERSION = 5
+export const PERSISTENCE_VERSION = 6

--- a/tests/unit/wardrobe.test.ts
+++ b/tests/unit/wardrobe.test.ts
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict'
 import {
   matchWardrobeRequest,
   pickWardrobePhrases,
+  resolveSlotConflicts,
   ACCESSORY_SLOT,
   OUTFIT_COLOR_HEX,
 } from '../../src/game/character/wardrobe'
@@ -45,7 +46,7 @@ describe('matchWardrobeRequest', () => {
   test("matches Santiago's request: a green shirt", () => {
     const result = matchWardrobeRequest('How do you change clothes? I want a green shirt.')
     assert.ok(result)
-    const shirt = shirtChange(result.changes)
+    const shirt = shirtChange(result)
     assert.ok(shirt)
     assert.equal(shirt.color, 'green')
   })
@@ -53,27 +54,27 @@ describe('matchWardrobeRequest', () => {
   test('color word applies to the following garment', () => {
     const result = matchWardrobeRequest('please wear a red shirt')
     assert.ok(result)
-    assert.deepEqual(shirtChange(result.changes), { kind: 'shirt', color: 'red' })
+    assert.deepEqual(shirtChange(result), { kind: 'shirt', color: 'red' })
   })
 
   test('multiple colored garments each get their own color', () => {
     const result = matchWardrobeRequest('green shirt and blue pants please')
     assert.ok(result)
-    assert.equal(shirtChange(result.changes)?.color, 'green')
-    assert.equal(pantsChange(result.changes)?.color, 'blue')
+    assert.equal(shirtChange(result)?.color, 'green')
+    assert.equal(pantsChange(result)?.color, 'blue')
   })
 
   test('color synonyms map to canonical colors', () => {
     assert.equal(
-      shirtChange(matchWardrobeRequest('a crimson shirt')!.changes)?.color,
+      shirtChange(matchWardrobeRequest('a crimson shirt')!)?.color,
       'red',
     )
     assert.equal(
-      shirtChange(matchWardrobeRequest('a navy sweater')!.changes)?.color,
+      shirtChange(matchWardrobeRequest('a navy sweater')!)?.color,
       'blue',
     )
     assert.equal(
-      pantsChange(matchWardrobeRequest('grey trousers')!.changes)?.color,
+      pantsChange(matchWardrobeRequest('grey trousers')!)?.color,
       'gray',
     )
   })
@@ -81,7 +82,7 @@ describe('matchWardrobeRequest', () => {
   test('garment without a color still matches (seeded random color)', () => {
     const result = matchWardrobeRequest('put on a new shirt', 7)
     assert.ok(result)
-    const shirt = shirtChange(result.changes)
+    const shirt = shirtChange(result)
     assert.ok(shirt)
     assert.ok(OutfitColorSchema.safeParse(shirt.color).success)
     // Deterministic for the same message and seed
@@ -92,50 +93,50 @@ describe('matchWardrobeRequest', () => {
   test('jeans default to blue', () => {
     const result = matchWardrobeRequest('wear some jeans')
     assert.ok(result)
-    assert.equal(pantsChange(result.changes)?.color, 'blue')
+    assert.equal(pantsChange(result)?.color, 'blue')
   })
 
   test('generic outfit change produces shirt and pants changes', () => {
     const result = matchWardrobeRequest('time to change your clothes')
     assert.ok(result)
-    assert.ok(shirtChange(result.changes))
-    assert.ok(pantsChange(result.changes))
+    assert.ok(shirtChange(result))
+    assert.ok(pantsChange(result))
   })
 
   test('colored outfit change applies the color to shirt and pants', () => {
     const result = matchWardrobeRequest('put on some purple clothes')
     assert.ok(result)
-    assert.equal(shirtChange(result.changes)?.color, 'purple')
-    assert.equal(pantsChange(result.changes)?.color, 'purple')
+    assert.equal(shirtChange(result)?.color, 'purple')
+    assert.equal(pantsChange(result)?.color, 'purple')
   })
 
   test('matches accessories', () => {
     assert.deepEqual(
-      accessoryItems(matchWardrobeRequest('put on sunglasses')!.changes),
+      accessoryItems(matchWardrobeRequest('put on sunglasses')!),
       ['SUNGLASSES'],
     )
     assert.deepEqual(
-      accessoryItems(matchWardrobeRequest('you need a scarf')!.changes),
+      accessoryItems(matchWardrobeRequest('you need a scarf')!),
       ['SCARF'],
     )
     assert.deepEqual(
-      accessoryItems(matchWardrobeRequest('grow a mustache')!.changes),
+      accessoryItems(matchWardrobeRequest('grow a mustache')!),
       ['MUSTACHE'],
     )
   })
 
   test('multi-word accessory beats the bare hat fallback', () => {
     assert.deepEqual(
-      accessoryItems(matchWardrobeRequest('wear a cowboy hat')!.changes),
+      accessoryItems(matchWardrobeRequest('wear a cowboy hat')!),
       ['COWBOY_HAT'],
     )
     assert.deepEqual(
-      accessoryItems(matchWardrobeRequest('a top hat would be fancy')!.changes),
+      accessoryItems(matchWardrobeRequest('a top hat would be fancy')!),
       ['TOP_HAT'],
     )
     // Bare "hat" falls back to the cap
     assert.deepEqual(
-      accessoryItems(matchWardrobeRequest('put on a hat')!.changes),
+      accessoryItems(matchWardrobeRequest('put on a hat')!),
       ['CAP'],
     )
   })
@@ -143,47 +144,62 @@ describe('matchWardrobeRequest', () => {
   test('t-shirt survives tokenization', () => {
     const result = matchWardrobeRequest('a yellow t-shirt')
     assert.ok(result)
-    assert.equal(shirtChange(result.changes)?.color, 'yellow')
+    assert.equal(shirtChange(result)?.color, 'yellow')
   })
 
   test('accessories in different slots can be combined', () => {
     const result = matchWardrobeRequest('top hat, sunglasses and a bow tie')
     assert.ok(result)
-    const items = accessoryItems(result.changes)
+    const items = accessoryItems(result)
     assert.deepEqual(items.sort(), ['BOW_TIE', 'SUNGLASSES', 'TOP_HAT'])
   })
 
   test('conflicting same-slot mentions collapse to the last one', () => {
     const result = matchWardrobeRequest('forget the cowboy hat, wear the crown')
     assert.ok(result)
-    assert.deepEqual(accessoryItems(result.changes), ['CROWN'])
+    assert.deepEqual(accessoryItems(result), ['CROWN'])
   })
 
   test('later garment mention overrides an earlier outfit change', () => {
     const result = matchWardrobeRequest('change clothes, and make the shirt green')
     assert.ok(result)
-    assert.equal(shirtChange(result.changes)?.color, 'green')
-    assert.ok(pantsChange(result.changes))
+    assert.equal(shirtChange(result)?.color, 'green')
+    assert.ok(pantsChange(result))
   })
 
   test('color after the garment works: make the pants red', () => {
     const result = matchWardrobeRequest('make the pants red')
     assert.ok(result)
-    assert.equal(pantsChange(result.changes)?.color, 'red')
+    assert.equal(pantsChange(result)?.color, 'red')
   })
 
   test('trailing color is not stolen from the next garment', () => {
     const result = matchWardrobeRequest('a shirt and blue pants')
     assert.ok(result)
-    assert.equal(pantsChange(result.changes)?.color, 'blue')
+    assert.equal(pantsChange(result)?.color, 'blue')
     // Shirt got its own (random) color, not blue by theft — any valid color ok
-    assert.ok(OutfitColorSchema.safeParse(shirtChange(result.changes)?.color).success)
+    assert.ok(OutfitColorSchema.safeParse(shirtChange(result)?.color).success)
   })
 
-  test('matchedKeyword reports the first clothing keyword', () => {
-    const result = matchWardrobeRequest('I want a green shirt')
-    assert.ok(result)
-    assert.equal(result.matchedKeyword, 'shirt')
+})
+
+// ---------------------------------------------------------------------------
+// resolveSlotConflicts
+// ---------------------------------------------------------------------------
+
+describe('resolveSlotConflicts', () => {
+  test('keeps at most one item per slot, last wins', () => {
+    assert.deepEqual(
+      resolveSlotConflicts(['COWBOY_HAT', 'SUNGLASSES', 'TOP_HAT']),
+      ['TOP_HAT', 'SUNGLASSES'],
+    )
+  })
+
+  test('leaves a conflict-free list unchanged', () => {
+    assert.deepEqual(
+      resolveSlotConflicts(['CROWN', 'SCARF', 'MUSTACHE']),
+      ['CROWN', 'SCARF', 'MUSTACHE'],
+    )
   })
 })
 

--- a/tests/unit/wardrobe.test.ts
+++ b/tests/unit/wardrobe.test.ts
@@ -1,0 +1,226 @@
+// ---------------------------------------------------------------------------
+// Unit tests for wardrobe keyword matching
+// ---------------------------------------------------------------------------
+//
+// These tests verify that visitor messages asking for clothing changes are
+// correctly parsed into wardrobe changes (accessories, shirt/pants colors).
+//
+// Run:  npm run test:unit
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  matchWardrobeRequest,
+  pickWardrobePhrases,
+  ACCESSORY_SLOT,
+  OUTFIT_COLOR_HEX,
+} from '../../src/game/character/wardrobe'
+import type { WardrobeChange } from '../../src/game/character/wardrobe'
+import { ClothingItemSchema, OutfitColorSchema } from '../../src/lib/characterSchema'
+
+function shirtChange(changes: WardrobeChange[]) {
+  return changes.find((c) => c.kind === 'shirt')
+}
+function pantsChange(changes: WardrobeChange[]) {
+  return changes.find((c) => c.kind === 'pants')
+}
+function accessoryItems(changes: WardrobeChange[]): string[] {
+  return changes.filter((c) => c.kind === 'accessory').map((c) => c.item)
+}
+
+// ---------------------------------------------------------------------------
+// matchWardrobeRequest
+// ---------------------------------------------------------------------------
+
+describe('matchWardrobeRequest', () => {
+  test('returns null for empty and unrelated messages', () => {
+    assert.equal(matchWardrobeRequest(''), null)
+    assert.equal(matchWardrobeRequest('just vibing'), null)
+    assert.equal(matchWardrobeRequest('what a lovely house'), null)
+    // A bare color with no garment is not a request
+    assert.equal(matchWardrobeRequest('green is my favorite color'), null)
+  })
+
+  test("matches Santiago's request: a green shirt", () => {
+    const result = matchWardrobeRequest('How do you change clothes? I want a green shirt.')
+    assert.ok(result)
+    const shirt = shirtChange(result.changes)
+    assert.ok(shirt)
+    assert.equal(shirt.color, 'green')
+  })
+
+  test('color word applies to the following garment', () => {
+    const result = matchWardrobeRequest('please wear a red shirt')
+    assert.ok(result)
+    assert.deepEqual(shirtChange(result.changes), { kind: 'shirt', color: 'red' })
+  })
+
+  test('multiple colored garments each get their own color', () => {
+    const result = matchWardrobeRequest('green shirt and blue pants please')
+    assert.ok(result)
+    assert.equal(shirtChange(result.changes)?.color, 'green')
+    assert.equal(pantsChange(result.changes)?.color, 'blue')
+  })
+
+  test('color synonyms map to canonical colors', () => {
+    assert.equal(
+      shirtChange(matchWardrobeRequest('a crimson shirt')!.changes)?.color,
+      'red',
+    )
+    assert.equal(
+      shirtChange(matchWardrobeRequest('a navy sweater')!.changes)?.color,
+      'blue',
+    )
+    assert.equal(
+      pantsChange(matchWardrobeRequest('grey trousers')!.changes)?.color,
+      'gray',
+    )
+  })
+
+  test('garment without a color still matches (seeded random color)', () => {
+    const result = matchWardrobeRequest('put on a new shirt', 7)
+    assert.ok(result)
+    const shirt = shirtChange(result.changes)
+    assert.ok(shirt)
+    assert.ok(OutfitColorSchema.safeParse(shirt.color).success)
+    // Deterministic for the same message and seed
+    const again = matchWardrobeRequest('put on a new shirt', 7)
+    assert.deepEqual(result, again)
+  })
+
+  test('jeans default to blue', () => {
+    const result = matchWardrobeRequest('wear some jeans')
+    assert.ok(result)
+    assert.equal(pantsChange(result.changes)?.color, 'blue')
+  })
+
+  test('generic outfit change produces shirt and pants changes', () => {
+    const result = matchWardrobeRequest('time to change your clothes')
+    assert.ok(result)
+    assert.ok(shirtChange(result.changes))
+    assert.ok(pantsChange(result.changes))
+  })
+
+  test('colored outfit change applies the color to shirt and pants', () => {
+    const result = matchWardrobeRequest('put on some purple clothes')
+    assert.ok(result)
+    assert.equal(shirtChange(result.changes)?.color, 'purple')
+    assert.equal(pantsChange(result.changes)?.color, 'purple')
+  })
+
+  test('matches accessories', () => {
+    assert.deepEqual(
+      accessoryItems(matchWardrobeRequest('put on sunglasses')!.changes),
+      ['SUNGLASSES'],
+    )
+    assert.deepEqual(
+      accessoryItems(matchWardrobeRequest('you need a scarf')!.changes),
+      ['SCARF'],
+    )
+    assert.deepEqual(
+      accessoryItems(matchWardrobeRequest('grow a mustache')!.changes),
+      ['MUSTACHE'],
+    )
+  })
+
+  test('multi-word accessory beats the bare hat fallback', () => {
+    assert.deepEqual(
+      accessoryItems(matchWardrobeRequest('wear a cowboy hat')!.changes),
+      ['COWBOY_HAT'],
+    )
+    assert.deepEqual(
+      accessoryItems(matchWardrobeRequest('a top hat would be fancy')!.changes),
+      ['TOP_HAT'],
+    )
+    // Bare "hat" falls back to the cap
+    assert.deepEqual(
+      accessoryItems(matchWardrobeRequest('put on a hat')!.changes),
+      ['CAP'],
+    )
+  })
+
+  test('t-shirt survives tokenization', () => {
+    const result = matchWardrobeRequest('a yellow t-shirt')
+    assert.ok(result)
+    assert.equal(shirtChange(result.changes)?.color, 'yellow')
+  })
+
+  test('accessories in different slots can be combined', () => {
+    const result = matchWardrobeRequest('top hat, sunglasses and a bow tie')
+    assert.ok(result)
+    const items = accessoryItems(result.changes)
+    assert.deepEqual(items.sort(), ['BOW_TIE', 'SUNGLASSES', 'TOP_HAT'])
+  })
+
+  test('conflicting same-slot mentions collapse to the last one', () => {
+    const result = matchWardrobeRequest('forget the cowboy hat, wear the crown')
+    assert.ok(result)
+    assert.deepEqual(accessoryItems(result.changes), ['CROWN'])
+  })
+
+  test('later garment mention overrides an earlier outfit change', () => {
+    const result = matchWardrobeRequest('change clothes, and make the shirt green')
+    assert.ok(result)
+    assert.equal(shirtChange(result.changes)?.color, 'green')
+    assert.ok(pantsChange(result.changes))
+  })
+
+  test('color after the garment works: make the pants red', () => {
+    const result = matchWardrobeRequest('make the pants red')
+    assert.ok(result)
+    assert.equal(pantsChange(result.changes)?.color, 'red')
+  })
+
+  test('trailing color is not stolen from the next garment', () => {
+    const result = matchWardrobeRequest('a shirt and blue pants')
+    assert.ok(result)
+    assert.equal(pantsChange(result.changes)?.color, 'blue')
+    // Shirt got its own (random) color, not blue by theft — any valid color ok
+    assert.ok(OutfitColorSchema.safeParse(shirtChange(result.changes)?.color).success)
+  })
+
+  test('matchedKeyword reports the first clothing keyword', () => {
+    const result = matchWardrobeRequest('I want a green shirt')
+    assert.ok(result)
+    assert.equal(result.matchedKeyword, 'shirt')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Vocabulary consistency
+// ---------------------------------------------------------------------------
+
+describe('wardrobe vocabulary', () => {
+  test('every clothing item has an accessory slot', () => {
+    for (const item of ClothingItemSchema.options) {
+      assert.ok(ACCESSORY_SLOT[item], `missing slot for ${item}`)
+    }
+  })
+
+  test('every outfit color has a hex value', () => {
+    for (const color of OutfitColorSchema.options) {
+      const hex = OUTFIT_COLOR_HEX[color]
+      assert.equal(typeof hex, 'number', `missing hex for ${color}`)
+      assert.ok(hex >= 0 && hex <= 0xffffff)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// pickWardrobePhrases
+// ---------------------------------------------------------------------------
+
+describe('pickWardrobePhrases', () => {
+  test('returns 1-3 unique phrases', () => {
+    for (let seed = 0; seed < 20; seed++) {
+      const phrases = pickWardrobePhrases(seed)
+      assert.ok(phrases.length >= 1 && phrases.length <= 3)
+      assert.equal(new Set(phrases).size, phrases.length)
+    }
+  })
+
+  test('is deterministic for the same seed', () => {
+    assert.deepEqual(pickWardrobePhrases(42), pickWardrobePhrases(42))
+  })
+})


### PR DESCRIPTION
Visitor messages like 'I want a green shirt' or 'put on a top hat and
sunglasses' now send the character to the bedroom wardrobe to change:

- New wardrobe.ts parses garments (shirt/pants + 12 colors with synonyms,
  color-before or color-after phrasing), whole-outfit changes, and
  accessories from visitor messages
- 12 new accessories (top hat, cap, beanie, crown, party hat, sunglasses,
  glasses, bow tie, scarf, necklace, headphones, mustache) with one-per-slot
  replacement; cowboy hat unchanged
- Shirt/pants recoloring via applyOutfitColors, persisted as
  shirtColor/pantsColor in the character schema
- Character.changeClothes walks to the bedroom, performs 'dress' at the
  wardrobe, then applies all queued changes
- Narrow bedrooms (<8 wide) now get a compact armoire so the wardrobe
  destination always exists
- Bump PERSISTENCE_VERSION to 6 (schema change) and app to v0.4.48

Requested by @santiagosalvador2179 (for Popeye)