### PR TITLE
Fix inverted pan direction for touch and mouse drag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mi-casa-es-su-casa",
-  "version": "0.4.49",
+  "version": "0.4.50",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/components/BootScreen.tsx
+++ b/src/components/BootScreen.tsx
@@ -27,7 +27,7 @@ const SUFFIXES: { label: string; display: string; slug: string }[] = [
 // ─── Boot lines ───────────────────────────────────────────────────────────────
 
 const BOOT_LINES: string[] = [
-  'MI CASA ES SU CASA v0.4.49',
+  'MI CASA ES SU CASA v0.4.50',
   '',
   '',
   'LOADING HOUSE SUBSYSTEM.......... OK',

--- a/src/game/renderer.ts
+++ b/src/game/renderer.ts
@@ -884,12 +884,14 @@ export function initGame(
     },
     applyPanDeltaPixels(dx: number, dy: number) {
       // "Content follows finger": the world point under the touch stays fixed.
-      // X: screen-X and world-X both increase rightward → pan is inverse of drag: -= dx
-      // Y: screen-Y increases downward, world-Y increases upward → pan matches drag: += dy
+      // The camera looks in +Z, which mirrors world-X on screen (screen-right
+      // = world −X), so dragging right must increase camera X: += dx.
+      // Y: screen-Y increases downward, world-Y increases upward, and camera up
+      // is +Y — dragging down must raise the camera: += dy.
       const unitsPerPixelX = frustumVisibleW / canvas.clientWidth
       const unitsPerPixelY = frustumVisibleH / canvas.clientHeight
-      panWorldX -= dx * unitsPerPixelX
-      panWorldY -= dy * unitsPerPixelY
+      panWorldX += dx * unitsPerPixelX
+      panWorldY += dy * unitsPerPixelY
       panWorldX = clamp(panWorldX, -MAX_PAN_X, MAX_PAN_X)
       panWorldY = clamp(panWorldY, -MAX_PAN_Y, MAX_PAN_Y)
       applyPanZoom()


### PR DESCRIPTION
The camera looks in +Z, which mirrors world-X on screen, so the
previous -= dx made horizontal pans move opposite the finger; the
vertical sign was likewise flipped relative to the intended
content-follows-finger convention. Both axes now track the drag.